### PR TITLE
I've been working on generating READMEs with both English and Korean …

### DIFF
--- a/asCastBar/README.md
+++ b/asCastBar/README.md
@@ -1,0 +1,39 @@
+# asCastBar
+
+asCastBar enhances the default player casting bar in World of Warcraft.
+
+## Main Features
+
+1.  **Spell Icon Display**:
+    *   Shows the icon of the spell currently being cast or channeled, positioned to the left of the casting bar.
+    *   Helps in quickly identifying the spell in progress.
+
+2.  **Casting Timer (Optional)**:
+    *   Displays a numerical timer on the casting bar, showing `current_cast_time / total_cast_time`.
+    *   This feature can be enabled or disabled by changing the `ACB_Casting_Time` variable in `asCastBar.lua`.
+
+## Customization
+
+*   The appearance and position of the spell icon can be adjusted by modifying values within the `asCastBar.lua` file.
+*   The casting timer's visibility is controlled by the `ACB_Casting_Time` variable in the Lua file.
+
+---
+
+# asCastBar
+
+asCastBar는 월드 오브 워크래프트의 기본 플레이어 시전 바를 강화하는 애드온입니다.
+
+## 주요 기능
+
+1.  **주문 아이콘 표시**:
+    *   현재 시전 중이거나 채널링 중인 주문의 아이콘을 시전 바 왼쪽에 표시합니다.
+    *   진행 중인 주문을 빠르게 식별하는 데 도움이 됩니다.
+
+2.  **시전 타이머 (선택 사항)**:
+    *   시전 바에 숫자 타이머를 표시하여 `현재_시전_시간 / 총_시전_시간`을 보여줍니다.
+    *   이 기능은 `asCastBar.lua` 파일의 `ACB_Casting_Time` 변수를 변경하여 활성화하거나 비활성화할 수 있습니다.
+
+## 사용자 설정
+
+*   주문 아이콘의 모양과 위치는 `asCastBar.lua` 파일 내의 값을 수정하여 조정할 수 있습니다.
+*   시전 타이머의 표시는 Lua 파일의 `ACB_Casting_Time` 변수로 제어됩니다.

--- a/asCastingAlert/README.md
+++ b/asCastingAlert/README.md
@@ -1,0 +1,71 @@
+# asCastingAlert
+
+asCastingAlert provides on-screen alerts for spells being cast by hostile units, particularly those targeting the player or by boss units.
+
+## Main Features
+
+1.  **Enemy Casting Notifications**:
+    *   Displays a list of spells currently being cast or channeled by attackable enemies and boss units.
+    *   Each entry shows the spell icon and the remaining cast time.
+    *   Helps players to be aware of incoming spells, especially in hectic encounters.
+
+2.  **Prioritization of Dangerous Spells**:
+    *   Highlights spells deemed "dangerous" in red for easier identification.
+    *   Integrates with DBM (Deadly Boss Mods): If DBM is installed, asCastingAlert can use DBM's information to identify and mark dangerous spells.
+
+3.  **Customizable Display**:
+    *   Maximum number of spells to display (`ACTA_MaxShow`).
+    *   Font size for the alert text (`ACTA_FontSize`).
+    *   Screen position of the alert frame (`ACTA_X`, `ACTA_Y`).
+    *   These settings are configured by modifying variables at the top of `asCastingAlert.lua`.
+
+4.  **Tooltip Information**:
+    *   Hovering over a spell icon in the alert list will show the game's default tooltip for that spell.
+
+5.  **Dynamic List**:
+    *   Alerts are dynamically added and removed as enemies start and stop casting.
+
+## Configuration
+
+Customization requires editing Lua variables at the beginning of the `asCastingAlert.lua` file:
+*   `ACTA_UpdateRate`: How often the addon checks for casting spells (in seconds).
+*   `ACTA_MaxShow`: The maximum number of spell alerts to show simultaneously.
+*   `ACTA_FontSize`: The font size for the spell name and timer.
+*   `ACTA_X`, `ACTA_Y`: The X and Y coordinates for the center of the alert display.
+
+---
+
+# asCastingAlert
+
+asCastingAlert는 적대적 유닛, 특히 플레이어를 대상으로 하거나 보스 유닛이 시전하는 주문에 대해 화면에 알림을 제공하는 애드온입니다.
+
+## 주요 기능
+
+1.  **적 시전 알림**:
+    *   공격 가능한 적 및 보스 유닛이 현재 시전 중이거나 채널링 중인 주문 목록을 표시합니다.
+    *   각 항목에는 주문 아이콘과 남은 시전 시간이 표시됩니다.
+    *   플레이어가 특히 정신없는 전투 중에 들어오는 주문을 인지하도록 도와줍니다.
+
+2.  **위험 주문 우선 표시**:
+    *   "위험하다고" 간주되는 주문을 빨간색으로 강조하여 쉽게 식별할 수 있도록 합니다.
+    *   DBM (Deadly Boss Mods)과 연동: DBM이 설치된 경우, asCastingAlert는 DBM의 정보를 사용하여 위험 주문을 식별하고 표시할 수 있습니다.
+
+3.  **사용자 설정 가능한 표시**:
+    *   표시할 최대 주문 수 (`ACTA_MaxShow`).
+    *   알림 텍스트의 글꼴 크기 (`ACTA_FontSize`).
+    *   알림 프레임의 화면 위치 (`ACTA_X`, `ACTA_Y`).
+    *   이러한 설정은 `asCastingAlert.lua` 파일 상단의 변수를 수정하여 구성합니다.
+
+4.  **툴팁 정보**:
+    *   알림 목록의 주문 아이콘 위에 마우스를 올리면 해당 주문에 대한 게임 기본 툴팁이 표시됩니다.
+
+5.  **동적 목록**:
+    *   적이 주문 시전을 시작하거나 중지함에 따라 알림이 동적으로 추가되고 제거됩니다.
+
+## 설정
+
+사용자 설정은 `asCastingAlert.lua` 파일 시작 부분의 Lua 변수를 편집해야 합니다:
+*   `ACTA_UpdateRate`: 애드온이 시전 주문을 확인하는 빈도 (초 단위).
+*   `ACTA_MaxShow`: 동시에 표시할 최대 주문 알림 수.
+*   `ACTA_FontSize`: 주문 이름 및 타이머의 글꼴 크기.
+*   `ACTA_X`, `ACTA_Y`: 알림 표시 중앙의 X 및 Y 좌표.

--- a/asDBMCastingAlert/README.md
+++ b/asDBMCastingAlert/README.md
@@ -1,0 +1,113 @@
+# asDBMCastingAlert
+
+asDBMCastingAlert provides advanced, customizable visual and auditory alerts for important enemy spell casts, with a strong emphasis on integration with Deadly Boss Mods (DBM). It is designed to help players react quickly to critical mechanics.
+
+## Main Features
+
+1.  **Dedicated Alert Bars**:
+    *   Displays up to three dedicated bars for spells identified as important by DBM.
+    *   Prioritizes showing spells from your `focus` target, then your current `target`, then other relevant units.
+    *   Each bar shows the spell icon, spell name, remaining cast/channel time, and the target of the spell (if applicable).
+
+2.  **DBM Integration**:
+    *   Relies on DBM's data to determine which spells are "dangerous" and require an alert.
+    *   Alerts are typically for spells that DBM flags for interrupts, stuns, or other special attention.
+
+3.  **Visual Cues**:
+    *   **Color Coding**: Casting bars are color-coded based on whether the spell is interruptible and whether the player is the direct target.
+        *   Default colors distinguish between:
+            *   Interruptible (player is target)
+            *   Interruptible (player is not target)
+            *   Not Interruptible (player is target)
+            *   Not Interruptible (player is not target)
+    *   **Interrupt Glow**: Spells that DBM marks as needing an interrupt will have a glowing border around the bar and icon.
+    *   **Raid Target Icons**: Displays the assigned raid target icon (skull, cross, etc.) on the spell icon.
+
+4.  **Auditory Alerts (Voice Notifications)**:
+    *   Provides voice callouts for critical spell casts.
+    *   Different sounds for:
+        *   General interruptible spell ("Kick")
+        *   General non-interruptible spell ("Stun")
+        *   Interruptible spell from **focus** target ("Focus Kick")
+        *   Non-interruptible spell from **focus** target ("Focus Stun")
+        *   Interruptible spell from current **target** ("Target Kick")
+        *   Non-interruptible spell from current **target** ("Target Stun")
+    *   Supports both English and Korean voice packs, selected based on client locale.
+    *   A delay prevents the same voice alert from playing too frequently.
+
+5.  **Customization**:
+    *   Many visual aspects (bar size, position, colors, transparency, font sizes) can be configured by editing variables at the top of `asDBMCastingAlert.lua`.
+    *   Sound settings (voice pack paths, playback speed, repeat delay) are also configurable in the Lua file.
+    *   If the `asMOD` addon is installed, some settings like the frame position can be configured through `asMOD`'s options panel.
+
+6.  **Filtering**:
+    *   Includes an option (`ns.options.HideTarget`) to hide alerts for the current target if it is not also the focus target, reducing clutter.
+
+## Configuration Variables (in `asDBMCastingAlert.lua`)
+
+*   `CONFIG_SOUND_SPEED`: Playback speed for voice alerts.
+*   `CONFIG_X`, `CONFIG_Y`: Default X and Y position of the alert frame anchor.
+*   `CONFIG_SIZE`: Base size for icon-related elements.
+*   `CONFIG_VOICE_DELAY`: Minimum delay (in seconds) before repeating the same voice alert.
+*   `CONFIG_WIDTH`, `CONFIG_HEIGHT`: Dimensions of the individual alert bars.
+*   `CONFIG_ALPHA`: Transparency of the alert bars.
+*   Color variables (e.g., `CONFIG_NOT_INTERRUPTIBLE_COLOR`): Define the RGB colors for different bar states.
+*   Voice file paths (e.g., `CONFIG_VOICE_TARGET_KICK`): Paths to the sound files for alerts.
+
+---
+
+# asDBMCastingAlert
+
+asDBMCastingAlert는 중요한 적 주문 시전에 대해 고급 사용자 정의가 가능한 시각 및 청각 알림을 제공하며, Deadly Boss Mods (DBM)와의 연동에 중점을 둡니다. 플레이어가 중요한 메커니즘에 빠르게 반응하도록 돕기 위해 설계되었습니다.
+
+## 주요 기능
+
+1.  **전용 알림 바**:
+    *   DBM에 의해 중요하다고 식별된 주문에 대해 최대 3개의 전용 바를 표시합니다.
+    *   `주시대상`의 주문을 우선 표시하고, 그 다음 현재 `대상`, 그리고 다른 관련 유닛 순으로 표시합니다.
+    *   각 바에는 주문 아이콘, 주문 이름, 남은 시전/채널링 시간 및 주문 대상(해당되는 경우)이 표시됩니다.
+
+2.  **DBM 연동**:
+    *   어떤 주문이 "위험"하고 알림이 필요한지 결정하기 위해 DBM의 데이터에 의존합니다.
+    *   알림은 일반적으로 DBM이 차단, 기절 또는 기타 특별한 주의가 필요하다고 표시한 주문에 대해 발생합니다.
+
+3.  **시각적 신호**:
+    *   **색상 코딩**: 시전 바는 주문 차단 가능 여부 및 플레이어가 직접적인 대상인지 여부에 따라 색상으로 구분됩니다.
+        *   기본 색상은 다음을 구분합니다:
+            *   차단 가능 (플레이어가 대상)
+            *   차단 가능 (플레이어가 대상이 아님)
+            *   차단 불가능 (플레이어가 대상)
+            *   차단 불가능 (플레이어가 대상이 아님)
+    *   **차단 강조**: DBM이 차단이 필요하다고 표시한 주문은 바와 아이콘 주위에 빛나는 테두리가 생깁니다.
+    *   **공격대 대상 아이콘**: 주문 아이콘에 할당된 공격대 대상 아이콘(해골, X자 등)을 표시합니다.
+
+4.  **청각 알림 (음성 안내)**:
+    *   중요한 주문 시전에 대한 음성 안내를 제공합니다.
+    *   다음과 같은 상황에 따라 다른 사운드가 재생됩니다:
+        *   일반적인 차단 가능 주문 ("차단")
+        *   일반적인 차단 불가능 주문 ("기절")
+        *   **주시대상**의 차단 가능 주문 ("주시 차단")
+        *   **주시대상**의 차단 불가능 주문 ("주시 기절")
+        *   현재 **대상**의 차단 가능 주문 ("대상 차단")
+        *   현재 **대상**의 차단 불가능 주문 ("대상 기절")
+    *   클라이언트 로케일에 따라 영어 및 한국어 음성 팩을 모두 지원합니다.
+    *   딜레이 기능이 있어 동일한 음성 알림이 너무 자주 반복되는 것을 방지합니다.
+
+5.  **사용자 설정**:
+    *   다양한 시각적 요소(바 크기, 위치, 색상, 투명도, 글꼴 크기)는 `asDBMCastingAlert.lua` 파일 상단의 변수를 편집하여 구성할 수 있습니다.
+    *   사운드 설정(음성 팩 경로, 재생 속도, 반복 지연) 또한 Lua 파일에서 구성할 수 있습니다.
+    *   `asMOD` 애드온이 설치된 경우, 프레임 위치와 같은 일부 설정은 `asMOD`의 옵션 패널을 통해 구성할 수 있습니다.
+
+6.  **필터링**:
+    *   현재 대상이 주시 대상이 아닌 경우 해당 대상에 대한 알림을 숨기는 옵션 (`ns.options.HideTarget`)을 포함하여 화면 혼잡을 줄입니다.
+
+## 설정 변수 (in `asDBMCastingAlert.lua`)
+
+*   `CONFIG_SOUND_SPEED`: 음성 알림 재생 속도.
+*   `CONFIG_X`, `CONFIG_Y`: 알림 프레임 앵커의 기본 X 및 Y 위치.
+*   `CONFIG_SIZE`: 아이콘 관련 요소의 기본 크기.
+*   `CONFIG_VOICE_DELAY`: 동일한 음성 알림을 반복하기 전 최소 지연 시간 (초 단위).
+*   `CONFIG_WIDTH`, `CONFIG_HEIGHT`: 개별 알림 바의 크기.
+*   `CONFIG_ALPHA`: 알림 바의 투명도.
+*   색상 변수 (예: `CONFIG_NOT_INTERRUPTIBLE_COLOR`): 다양한 바 상태에 대한 RGB 색상을 정의합니다.
+*   음성 파일 경로 (예: `CONFIG_VOICE_TARGET_KICK`): 알림용 사운드 파일 경로.

--- a/asDBMTimer/README.md
+++ b/asDBMTimer/README.md
@@ -1,0 +1,105 @@
+# asDBMTimer
+
+asDBMTimer provides a configurable visual display for Deadly Boss Mods (DBM) timers, arranging them as a dynamic vertical timeline on your screen.
+
+## Main Features
+
+1.  **DBM Timer Visualization**:
+    *   Integrates with DBM to capture timer events (start, stop, update) for both standard DBM timers and DBM's nameplate-specific timers.
+    *   Displays these timers as a list of icons, each with a cooldown countdown and a descriptive label.
+
+2.  **Vertical Timeline Display**:
+    *   Timers are arranged vertically on the screen.
+    *   The vertical position of each timer icon dynamically represents its remaining duration; as time progresses, icons move downwards.
+    *   The amount of screen height that represents one second of cooldown time is configurable (`ADBMT_1sHeight`), allowing users to adjust the visual spacing and speed.
+
+3.  **Detailed Timer Elements**:
+    *   **Icon**: Shows the spell or event icon provided by DBM.
+    *   **Cooldown Text**: Displays a numerical countdown (e.g., "03.1"). The text turns red when the remaining time is 3 seconds or less.
+    *   **Descriptive Label**: Shows the DBM timer message (e.g., "Boss Ability Name"). This label can be prefixed with a type (e.g., "[AOE]", "[Interrupt]") and color-coded based on DBM's timer categories.
+    *   **Raid Target Icons**: If a timer is associated with a specific unit (often from nameplate timers) that has a raid target icon (skull, cross, etc.), this icon is displayed next to the timer label.
+
+4.  **Color-Coded Timer Types**:
+    *   Timer labels are colored according to DBM's classification of the timer (e.g., Add, AOE, Targeted, Interrupt, Role, Phase, Important).
+    *   Specific color schemes are defined for both English and Korean client locales.
+
+5.  **Filtering and Management**:
+    *   Timers are only displayed if their remaining duration is below a configurable threshold (`ns.options.MinTimetoShow` - likely managed by `asMOD` or a shared options panel).
+    *   Timers associated with units that die are automatically removed.
+    *   A maximum number of simultaneously displayed timers can be set (`ADBMT_MaxButtons`).
+
+6.  **Auditory Alert for AOE**:
+    *   Optionally plays a sound alert when an AOE-classified DBM timer is about to expire (configurable threshold `ns.options.AOESound`).
+    *   Uses different sound files for English and Korean locales.
+
+7.  **Customization (via `asDBMTimer.lua` and `asMOD` options)**:
+    *   **Visuals**: Font, font sizes, font outline, icon size, overall frame position (`ADBMT_X`, `ADBMT_Y`), vertical scaling of the timeline (`ADBMT_1sHeight`).
+    *   **Behavior**: Maximum number of timers to display.
+    *   **Integration**: If `asMOD` is installed, the main frame's position can be adjusted via `asMOD`'s configuration. Some options like `MinTimetoShow` and `AOESound` are likely managed through `asMOD`'s shared options system (`ns.options`).
+
+8.  **Tooltip Support**:
+    *   Hovering over a timer's icon will display the standard game tooltip for the associated spell, if applicable.
+
+## Configuration Variables (primarily in `asDBMTimer.lua`)
+
+*   `ADBMT_Font`, `ADBMT_CoolFontSize`, `ADBMT_NameFontSize`, `ADBMT_FontOutline`: Font settings for text elements.
+*   `ADBMT_MaxButtons`: Maximum number of timers to display at once.
+*   `ADBMT_1sHeight`: Defines how many pixels of vertical space correspond to one second of timer duration.
+*   `ADBMT_IconSize`: The size of the timer icons.
+*   `ADBMT_X`, `ADBMT_Y`: Default X and Y coordinates for the main timer frame anchor.
+*   `BarColors`: Lua table defining the RGB colors and text prefixes for different DBM timer categories.
+*   `AOEVoice`: Path to the sound file for AOE timer alerts.
+
+---
+
+# asDBMTimer
+
+asDBMTimer는 Deadly Boss Mods (DBM) 타이머에 대한 설정 가능한 시각적 표시를 제공하며, 화면에 동적 수직 타임라인으로 배열합니다.
+
+## 주요 기능
+
+1.  **DBM 타이머 시각화**:
+    *   DBM과 연동하여 표준 DBM 타이머 및 DBM의 이름표 전용 타이머 모두에 대한 타이머 이벤트(시작, 중지, 업데이트)를 포착합니다.
+    *   이러한 타이머를 아이콘 목록으로 표시하며, 각 아이콘에는 재사용 대기시간 카운트다운과 설명 레이블이 함께 제공됩니다.
+
+2.  **수직 타임라인 표시**:
+    *   타이머는 화면에 수직으로 배열됩니다.
+    *   각 타이머 아이콘의 수직 위치는 남은 지속 시간을 동적으로 나타냅니다. 시간이 지남에 따라 아이콘은 아래로 이동합니다.
+    *   1초의 재사용 대기시간을 나타내는 화면 높이의 양은 (`ADBMT_1sHeight`) 설정 가능하여 사용자가 시각적 간격과 속도를 조정할 수 있습니다.
+
+3.  **상세 타이머 요소**:
+    *   **아이콘**: DBM에서 제공하는 주문 또는 이벤트 아이콘을 표시합니다.
+    *   **재사용 대기시간 텍스트**: 숫자 카운트다운(예: "03.1")을 표시합니다. 남은 시간이 3초 이하일 때 텍스트가 빨간색으로 바뀝니다.
+    *   **설명 레이블**: DBM 타이머 메시지(예: "보스 기술 이름")를 표시합니다. 이 레이블에는 유형(예: "[광역]", "[차단]")이 접두사로 붙을 수 있으며 DBM의 타이머 범주에 따라 색상으로 구분될 수 있습니다.
+    *   **공격대 대상 아이콘**: 타이머가 특정 유닛(종종 이름표 타이머에서 유래)과 연관되어 있고 해당 유닛에 공격대 대상 아이콘(해골, X자 등)이 있는 경우, 이 아이콘이 타이머 레이블 옆에 표시됩니다.
+
+4.  **색상으로 구분된 타이머 유형**:
+    *   타이머 레이블은 DBM의 타이머 분류(예: 쫄, 광역, 대상 지정, 차단, 역할, 단계, 중요)에 따라 색상이 지정됩니다.
+    *   영어 및 한국어 클라이언트 로케일 모두에 대해 특정 색상 구성표가 정의되어 있습니다.
+
+5.  **필터링 및 관리**:
+    *   타이머는 남은 지속 시간이 설정 가능한 임계값(`ns.options.MinTimetoShow` - `asMOD` 또는 공유 옵션 패널에서 관리될 가능성이 높음) 미만인 경우에만 표시됩니다.
+    *   죽은 유닛과 관련된 타이머는 자동으로 제거됩니다.
+    *   동시에 표시되는 최대 타이머 수 (`ADBMT_MaxButtons`)를 설정할 수 있습니다.
+
+6.  **광역 기술에 대한 청각 알림**:
+    *   선택적으로 광역으로 분류된 DBM 타이머가 만료되기 직전(설정 가능한 임계값 `ns.options.AOESound`)에 사운드 알림을 재생합니다.
+    *   영어 및 한국어 로케일에 대해 다른 사운드 파일을 사용합니다.
+
+7.  **사용자 설정 (`asDBMTimer.lua` 및 `asMOD` 옵션을 통해)**:
+    *   **시각적 요소**: 글꼴, 글꼴 크기, 글꼴 외곽선, 아이콘 크기, 전체 프레임 위치 (`ADBMT_X`, `ADBMT_Y`), 타임라인의 수직 배율 (`ADBMT_1sHeight`).
+    *   **동작**: 표시할 최대 타이머 수.
+    *   **연동**: `asMOD`가 설치된 경우, 메인 프레임의 위치는 `asMOD`의 설정을 통해 조정할 수 있습니다. `MinTimetoShow` 및 `AOESound`와 같은 일부 옵션은 `asMOD`의 공유 옵션 시스템 (`ns.options`)을 통해 관리될 가능성이 높습니다.
+
+8.  **툴팁 지원**:
+    *   타이머 아이콘 위에 마우스를 올리면 해당 주문에 대한 표준 게임 툴팁(해당되는 경우)이 표시됩니다.
+
+## 설정 변수 (주로 `asDBMTimer.lua`에 있음)
+
+*   `ADBMT_Font`, `ADBMT_CoolFontSize`, `ADBMT_NameFontSize`, `ADBMT_FontOutline`: 텍스트 요소에 대한 글꼴 설정.
+*   `ADBMT_MaxButtons`: 한 번에 표시할 최대 타이머 수.
+*   `ADBMT_1sHeight`: 타이머 지속 시간 1초에 해당하는 수직 공간의 픽셀 수를 정의합니다.
+*   `ADBMT_IconSize`: 타이머 아이콘의 크기.
+*   `ADBMT_X`, `ADBMT_Y`: 메인 타이머 프레임 앵커의 기본 X 및 Y 좌표.
+*   `BarColors`: 다양한 DBM 타이머 범주에 대한 RGB 색상 및 텍스트 접두사를 정의하는 Lua 테이블.
+*   `AOEVoice`: 광역 타이머 알림용 사운드 파일 경로.

--- a/asDebuffFilter/README.md
+++ b/asDebuffFilter/README.md
@@ -1,0 +1,119 @@
+# asDebuffFilter
+
+asDebuffFilter is an advanced World of Warcraft addon that provides highly customizable display and filtering for debuffs on both the player and target unit frames. It aims to show only relevant debuffs, reducing clutter and highlighting important information.
+
+## Main Features
+
+1.  **Separate Player & Target Debuff Frames**:
+    *   Manages and displays debuffs in distinct, configurable frames for your character (`player`) and your current `target`.
+    *   Includes support for WoW's "Private Auras" on the player frame for special aura types.
+
+2.  **Advanced Debuff Filtering**:
+    *   **Global Blacklist**: Ignores specified spell IDs entirely (`ADF_BlackList`).
+    *   **Contextual Target Filtering**: Sophisticated rules (`ShouldShowDebuffs`) determine if a target's debuff is displayed, considering:
+        *   Whether the player or their pet cast it.
+        *   If the CVar `noBuffDebuffFilterOnTarget` is enabled.
+        *   The target's type (player, friendly, hostile NPC).
+    *   **Integration with other asMOD Addons**: Avoids duplicating debuffs already shown by other addons in the `asMOD` suite (like `asPowerBar` or `asCombatInfo`) by checking against their known spell lists.
+    *   **Player-Specific Filtering**: Can filter player debuffs by maximum duration (`ns.ADF_MAX_Cool`) and prioritizes raid or boss-sourced auras.
+    *   **Debuff Prioritization & Classification**:
+        *   Categorizes debuffs (e.g., `BossDebuff`, `PriorityDebuff`, `NonBossDebuff`, `L0` for player-cast) using various criteria.
+        *   Identifies "Priority Debuffs" using `SpellIsPriorityAura` and class-specific logic (e.g., Paladin's Forbearance).
+        *   Leverages knowledge of player-cast spells (from spellbook and talents) for better filtering.
+        *   Supports class/spec-specific override lists (`ns.ShowList_<CLASS>_<SPEC>`) for fine-grained control over individual spell display, alert conditions, and snapshot tracking.
+
+3.  **Visual Alerts and Customization**:
+    *   **Icon Display**: Standard debuff icons with cooldown timers and stack count text.
+    *   **Border Coloring**: Icon borders are colored according to the debuff's dispel type (Magic, Curse, Disease, Poison).
+    *   **Glow Effects for Actionable Debuffs**:
+        *   **Pixel Glow**: Applied to debuffs on friendly units (like the player) if the player possesses the ability to dispel that debuff type.
+        *   **Button Glow**: Applied to debuffs classified as `BossDebuff`.
+        *   Glows can also be triggered by custom conditions defined in class/spec-specific `show_list` tables (e.g., based on remaining duration or stack count).
+    *   **DoT Snapshot Display**: If `asDotSnapshot` addon is present, it can display the relative power of the player's Damage-over-Time effects on the target.
+    *   **Dynamic Sizing**: Debuff icons can be different sizes based on their classification (e.g., less important debuffs might appear smaller).
+
+4.  **Dynamic Updates & Configuration**:
+    *   **Event-Driven**: Updates reactively to game events such as `UNIT_AURA`, `PLAYER_TARGET_CHANGED`, talent updates, and entering/leaving combat.
+    *   **Periodic Refresh**: Target debuffs are also updated on a regular timer.
+    *   **Configuration (via `ns` namespace - likely from `asMOD` or shared options panel)**:
+        *   Icon sizes (`ns.ADF_SIZE`).
+        *   Maximum number of debuffs shown per frame (`ns.ADF_MAX_DEBUFF_SHOW`).
+        *   Frame positions for player and target debuffs.
+        *   Alpha levels for in-combat and out-of-combat states.
+        *   Font sizes for cooldown and stack count text.
+        *   Extensive class/specialization specific lists (`ns.ShowList_*`) allow deep customization of how individual debuffs are treated.
+
+5.  **Intelligent Spell Recognition**:
+    *   Scans the player's spellbook and selected talents to build a list of "known" spells, aiding in filtering for player-cast debuffs.
+    *   Dynamically determines which dispel types the player is capable of, to accurately highlight dispellable debuffs.
+
+## Configuration Notes
+
+Many settings for asDebuffFilter are managed through variables within the `ns` (namespace) table, which is typically part of the `asMOD` framework or a shared configuration library used by `asMOD` addons. This allows for centralized settings and in-game configuration options if `asMOD` is installed.
+
+Key configurable aspects include:
+*   Position and size of debuff frames and icons.
+*   Maximum number of debuffs to display.
+*   Filtering thresholds (e.g., maximum duration for player debuffs).
+*   Detailed, per-spell behavior through class/spec-specific `ShowList_*` tables.
+
+---
+
+# asDebuffFilter
+
+asDebuffFilter는 플레이어 및 대상 유닛 프레임 모두에서 디버프에 대한 고도로 사용자 정의 가능한 표시 및 필터링을 제공하는 고급 월드 오브 워크래프트 애드온입니다. 관련 있는 디버프만 표시하여 혼잡을 줄이고 중요한 정보를 강조하는 것을 목표로 합니다.
+
+## 주요 기능
+
+1.  **별도의 플레이어 및 대상 디버프 프레임**:
+    *   자신의 캐릭터(`player`)와 현재 `대상`에 대해 별개의 설정 가능한 프레임에서 디버프를 관리하고 표시합니다.
+    *   특수 오라 유형에 대해 플레이어 프레임에서 WoW의 "개인 오라"를 지원합니다.
+
+2.  **고급 디버프 필터링**:
+    *   **전역 블랙리스트**: 지정된 주문 ID를 완전히 무시합니다 (`ADF_BlackList`).
+    *   **상황별 대상 필터링**: 대상의 디버프 표시 여부를 결정하는 정교한 규칙 (`ShouldShowDebuffs`)으로 다음을 고려합니다:
+        *   플레이어 또는 플레이어의 소환수가 시전했는지 여부.
+        *   CVar `noBuffDebuffFilterOnTarget` 활성화 여부.
+        *   대상의 유형 (플레이어, 우호적, 적대적 NPC).
+    *   **다른 asMOD 애드온과의 연동**: `asMOD` 제품군의 다른 애드온(예: `asPowerBar` 또는 `asCombatInfo`)에 이미 표시된 디버프가 중복 표시되는 것을 방지하기 위해 해당 애드온의 알려진 주문 목록과 대조합니다.
+    *   **플레이어별 필터링**: 플레이어 디버프를 최대 지속 시간(`ns.ADF_MAX_Cool`)으로 필터링할 수 있으며 공격대 또는 보스로부터 비롯된 오라를 우선시합니다.
+    *   **디버프 우선 순위 지정 및 분류**:
+        *   다양한 기준을 사용하여 디버프를 분류합니다 (예: `BossDebuff`, `PriorityDebuff`, `NonBossDebuff`, 플레이어 시전의 경우 `L0`).
+        *   `SpellIsPriorityAura` 및 직업별 로직(예: 성기사의 인내)을 사용하여 "중요 디버프"를 식별합니다.
+        *   더 나은 필터링을 위해 플레이어가 시전한 주문(주문책 및 특성에서 가져옴)에 대한 지식을 활용합니다.
+        *   개별 주문 표시, 알림 조건 및 스냅샷 추적에 대한 세밀한 제어를 위해 직업/전문기술별 재정의 목록 (`ns.ShowList_<CLASS>_<SPEC>`)을 지원합니다.
+
+3.  **시각적 알림 및 사용자 설정**:
+    *   **아이콘 표시**: 재사용 대기시간 타이머 및 중첩 횟수 텍스트가 있는 표준 디버프 아이콘.
+    *   **테두리 색상 지정**: 아이콘 테두리는 디버프의 해제 유형(마법, 저주, 질병, 독)에 따라 색상이 지정됩니다.
+    *   **조치 가능한 디버프에 대한 강조 효과**:
+        *   **픽셀 강조**: 플레이어가 해당 디버프 유형을 해제할 수 있는 능력을 가지고 있는 경우, 우호적인 유닛(플레이어 등)의 디버프에 적용됩니다.
+        *   **버튼 강조**: `BossDebuff`로 분류된 디버프에 적용됩니다.
+        *   직업/전문기술별 `show_list` 테이블에 정의된 사용자 지정 조건(예: 남은 지속 시간 또는 중첩 횟수 기준)에 의해서도 강조 효과가 발동될 수 있습니다.
+    *   **DoT 스냅샷 표시**: `asDotSnapshot` 애드온이 있는 경우 대상에 대한 플레이어의 지속적인 피해 효과(DoT)의 상대적인 위력을 표시할 수 있습니다.
+    *   **동적 크기 조정**: 디버프 아이콘은 분류에 따라 크기가 다를 수 있습니다 (예: 덜 중요한 디버프는 더 작게 표시될 수 있음).
+
+4.  **동적 업데이트 및 설정**:
+    *   **이벤트 기반**: `UNIT_AURA`, `PLAYER_TARGET_CHANGED`, 특성 업데이트, 전투 시작/종료와 같은 게임 이벤트에 반응적으로 업데이트됩니다.
+    *   **주기적 새로고침**: 대상 디버프도 일정한 간격으로 업데이트됩니다.
+    *   **설정 (`ns` 네임스페이스를 통해 - 일반적으로 `asMOD` 또는 공유 옵션 패널에서 비롯됨)**:
+        *   아이콘 크기 (`ns.ADF_SIZE`).
+        *   프레임당 표시할 최대 디버프 수 (`ns.ADF_MAX_DEBUFF_SHOW`).
+        *   플레이어 및 대상 디버프 프레임 위치.
+        *   전투 중 및 비전투 중 알파 레벨.
+        *   재사용 대기시간 및 중첩 횟수 텍스트의 글꼴 크기.
+        *   광범위한 직업/전문기술별 목록 (`ns.ShowList_*`)을 통해 개별 디버프 처리 방식을 심층적으로 사용자 정의할 수 있습니다.
+
+5.  **지능적인 주문 인식**:
+    *   플레이어의 주문책과 선택한 특성을 스캔하여 "알려진" 주문 목록을 작성하여 플레이어가 시전한 디버프 필터링을 지원합니다.
+    *   플레이어가 해제할 수 있는 디버프 유형을 동적으로 결정하여 해제 가능한 디버프를 정확하게 강조 표시합니다.
+
+## 설정 참고사항
+
+asDebuffFilter의 많은 설정은 `ns` (네임스페이스) 테이블 내의 변수를 통해 관리되며, 이는 일반적으로 `asMOD` 프레임워크 또는 `asMOD` 애드온에서 사용하는 공유 설정 라이브러리의 일부입니다. 이를 통해 `asMOD`가 설치된 경우 중앙 집중식 설정 및 게임 내 설정 옵션이 가능합니다.
+
+주요 설정 가능 요소는 다음과 같습니다:
+*   디버프 프레임 및 아이콘의 위치와 크기.
+*   표시할 최대 디버프 수.
+*   필터링 임계값 (예: 플레이어 디버프의 최대 지속 시간).
+*   직업/전문기술별 `ShowList_*` 테이블을 통한 상세한 주문별 동작.

--- a/asDotFilter/README.md
+++ b/asDotFilter/README.md
@@ -1,0 +1,87 @@
+# asDotFilter
+
+asDotFilter is a World of Warcraft addon designed to display player-cast Damage over Time (DoT) effects on specified unit frames, such as focus, boss frames, and the target frame. It helps players track their DoTs with visual cues for remaining duration, stack counts, and snapshot strength (if `asDotSnapshot` is available).
+
+## Main Features
+
+1.  **Player-Cast DoT Tracking**:
+    *   Focuses exclusively on DoTs cast by the player or their pet.
+    *   Uses predefined lists of spell IDs specific to each class and specialization to identify which DoTs to monitor.
+
+2.  **Configurable Unit Display**:
+    *   Displays tracked DoTs next to specified unit frames. By default, this includes `focus` and `boss1` through `boss5`.
+    *   The icons are dynamically positioned relative to the standard Blizzard unit frames or their `asUnitFrame` equivalents (e.g., `AUF_TargetFrame`) if available.
+
+3.  **Visual DoT Information**:
+    *   **Icon & Cooldown**: Shows the DoT's spell icon with a cooldown spiral and numerical text indicating remaining duration.
+    *   **Stack Count**: Displays the number of stacks for DoTs that can have multiple applications.
+    *   **Snapshot Strength (with asDotSnapshot)**: If the `asDotSnapshot` addon is installed, asDotFilter can display the relative power of the applied DoT as a percentage (e.g., "110" for 110%). The text color indicates if it's stronger (greenish) or weaker (reddish) than a baseline 100% snapshot.
+    *   **Duration Alert**: A glow effect is applied to the icon when a DoT's remaining duration falls below a configurable threshold (typically 30% of its base duration or a specific time in seconds, defined per spell in the lists).
+
+4.  **Class and Specialization Specific Lists**:
+    *   Contains hardcoded lists (e.g., `ADotF_ShowList_WARLOCK_1`) for each class and spec, defining:
+        *   The spell ID of the DoT.
+        *   A threshold for the duration alert glow.
+        *   An optional flag to enable snapshot power display via `asDotSnapshot`.
+    *   The addon automatically selects the correct list based on the player's current class and specialization.
+
+5.  **Dynamic Updates**:
+    *   Responds to game events such as target changes, focus changes, entering combat with a boss, and talent switches to update DoT displays.
+    *   A periodic timer also ensures DoTs are regularly refreshed.
+
+## Customization
+
+Core customization is done by editing Lua variables at the top of `asDotFilter/asDotFilter.lua`:
+
+*   `ADotF_SIZE`: Sets the size of the DoT icons.
+*   `ADotF_MAX_DEBUFF_SHOW`: Defines the maximum number of DoT icons to display per unit frame (though current logic seems to display all configured DoTs for a spec).
+*   `ADotF_ALPHA`: Controls the transparency of the DoT icons.
+*   `ADotF_CooldownFontSize`: Font size for the numerical cooldown text.
+*   `ADotF_CountFontSize`: Font size for the stack count text.
+*   `ADotF_UnitList`: A Lua table where you can specify which unit frames should have DoT icons displayed next to them (e.g., `"target"`, `"focus"`, `"boss1"`).
+*   **Spell Lists** (`ADotF_ShowList_<CLASS>_<SPEC>`): Advanced users can modify these lists to change which DoTs are tracked, their alert thresholds, or snapshot checking behavior.
+
+---
+
+# asDotFilter
+
+asDotFilter는 월드 오브 워크래프트 애드온으로, 플레이어가 시전한 지속적인 피해(DoT) 효과를 주시 대상, 보스 프레임, 대상 프레임 등 지정된 유닛 프레임에 표시하도록 설계되었습니다. 플레이어가 남은 지속 시간, 중첩 횟수, 그리고 (asDotSnapshot 애드온 사용 시) 스냅샷 강도에 대한 시각적 신호를 통해 자신의 DoT를 추적하는 데 도움을 줍니다.
+
+## 주요 기능
+
+1.  **플레이어 시전 DoT 추적**:
+    *   플레이어 또는 플레이어의 소환수가 시전한 DoT에만 집중합니다.
+    *   각 직업 및 전문화별로 미리 정의된 주문 ID 목록을 사용하여 어떤 DoT를 감시할지 식별합니다.
+
+2.  **설정 가능한 유닛 표시**:
+    *   추적된 DoT를 지정된 유닛 프레임 옆에 표시합니다. 기본적으로 `주시 대상` 및 `boss1`부터 `boss5`까지 포함됩니다.
+    *   아이콘은 표준 블리자드 유닛 프레임 또는 (사용 가능한 경우) `asUnitFrame`에 해당하는 프레임(예: `AUF_TargetFrame`)을 기준으로 동적으로 위치가 지정됩니다.
+
+3.  **시각적 DoT 정보**:
+    *   **아이콘 및 재사용 대기시간**: DoT의 주문 아이콘과 함께 남은 지속 시간을 나타내는 재사용 대기시간 효과 및 숫자 텍스트를 표시합니다.
+    *   **중첩 횟수**: 여러 번 적용될 수 있는 DoT의 중첩 횟수를 표시합니다.
+    *   **스냅샷 강도 (asDotSnapshot 연동 시)**: `asDotSnapshot` 애드온이 설치된 경우, asDotFilter는 적용된 DoT의 상대적인 위력을 백분율(예: 110% 위력일 경우 "110")로 표시할 수 있습니다. 텍스트 색상은 기준 100% 스냅샷보다 강한지(녹색 계열) 약한지(붉은색 계열)를 나타냅니다.
+    *   **지속 시간 알림**: DoT의 남은 지속 시간이 설정된 임계값(일반적으로 기본 지속 시간의 30% 또는 목록에 주문별로 정의된 특정 시간(초)) 아래로 떨어지면 아이콘에 강조 효과가 적용됩니다.
+
+4.  **직업 및 전문화별 목록**:
+    *   각 직업 및 전문화에 대한 하드코딩된 목록(예: `ADotF_ShowList_WARLOCK_1`)을 포함하며, 다음을 정의합니다:
+        *   DoT의 주문 ID.
+        *   지속 시간 알림 강조 효과의 임계값.
+        *   `asDotSnapshot`을 통한 스냅샷 위력 표시 활성화 여부 (선택 사항).
+    *   애드온은 플레이어의 현재 직업 및 전문화에 따라 올바른 목록을 자동으로 선택합니다.
+
+5.  **동적 업데이트**:
+    *   대상 변경, 주시 대상 변경, 보스 전투 시작, 특성 변경과 같은 게임 이벤트에 반응하여 DoT 표시를 업데이트합니다.
+    *   주기적인 타이머 또한 DoT가 정기적으로 새로고침되도록 보장합니다.
+
+## 사용자 설정
+
+핵심 사용자 설정은 `asDotFilter/asDotFilter.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `ADotF_SIZE`: DoT 아이콘의 크기를 설정합니다.
+*   `ADotF_MAX_DEBUFF_SHOW`: 유닛 프레임당 표시할 최대 DoT 아이콘 수를 정의합니다 (현재 로직은 전문화에 설정된 모든 DoT를 표시하는 것으로 보임).
+*   `ADotF_ALPHA`: DoT 아이콘의 투명도를 제어합니다.
+*   `ADotF_CooldownFontSize`: 숫자 재사용 대기시간 텍스트의 글꼴 크기.
+*   `ADotF_CountFontSize`: 중첩 횟수 텍스트의 글꼴 크기.
+*   `ADotF_UnitList`: DoT 아이콘을 표시할 유닛 프레임을 지정할 수 있는 Lua 테이블입니다 (예: `"target"`, `"focus"`, `"boss1"`).
+*   **주문 목록** (`ADotF_ShowList_<CLASS>_<SPEC>`): 고급 사용자는 이 목록을 수정하여 추적할 DoT, 알림 임계값 또는 스냅샷 확인 동작을 변경할 수 있습니다.

--- a/asDotSnapshot/README.md
+++ b/asDotSnapshot/README.md
@@ -1,0 +1,101 @@
+# asDotSnapshot
+
+asDotSnapshot is a World of Warcraft utility addon that calculates and stores the "snapshot" power of player-cast Damage over Time (DoT) effects. It is primarily designed for classes and specializations where DoT damage can vary significantly based on the buffs active at the moment of application (e.g., Feral Druid, Assassination Rogue). This addon itself does not display anything but provides data for other addons (like `asDotFilter`) to use.
+
+## Main Features
+
+1.  **DoT Snapshot Calculation**:
+    *   Monitors player buffs and relevant combat log events (`SPELL_AURA_APPLIED`, `SPELL_AURA_REFRESH`, `SPELL_AURA_REMOVED`).
+    *   When a player applies or refreshes a tracked DoT, the addon calculates a damage multiplier based on the buffs active at that precise moment.
+    *   This multiplier represents the "snapshotted" strength of that DoT instance.
+
+2.  **Class and Specialization Specific Logic**:
+    *   Currently supports:
+        *   **Feral Druid**: Tracks buffs like Tiger's Fury, Bloodtalons, Prowl/Stealth effects (for Rake), Clearcasting (for Thrash), and relevant talents affecting these.
+        *   **Assassination Rogue**: Tracks if Garrote was applied with Improved Garrote effects.
+    *   The addon loads specific buff/debuff/talent lists based on the player's current class and specialization. If a spec is not explicitly supported, the addon remains dormant.
+
+3.  **Data Provider for Other Addons**:
+    *   Stores the calculated snapshot values globally.
+    *   Exposes the function `asDotSnapshot.Relative(targetGUID, spellId)`:
+        *   Other addons can call this function to get the relative strength of a potential new DoT application compared to the one currently active on the target.
+        *   For example, a return value of `1.1` indicates a new application would be 10% stronger. A value of `0.9` indicates it would be 10% weaker.
+        *   If no DoT is currently snapshotted on the target for that spell, it returns the potential power of a new cast (e.g., `1.15` if Tiger's Fury is up).
+
+4.  **Dynamic Updates**:
+    *   Recalculates internal buff states and talent information upon player login, talent changes, and trait configuration updates.
+    *   Continuously updates knowledge of active player buffs via `UNIT_AURA` events.
+
+## How It Works
+
+1.  **Configuration Load**: On login or spec change, loads a predefined set of buffs, DoTs, and talents relevant to the player's class/spec.
+2.  **Buff Monitoring**: Keeps track of which configured buffs are currently active on the player.
+3.  **Combat Log Parsing**: When the player casts or refreshes a monitored DoT on a target:
+    *   It evaluates the active buffs.
+    *   Calculates a damage multiplier (e.g., if Tiger's Fury is up, the multiplier might be 1.15).
+    *   Stores this multiplier associated with that specific DoT on that specific target.
+4.  **Data Exposure**: Other addons can then query `asDotSnapshot.Relative()` to decide if reapplying a DoT would be beneficial.
+
+## Supported Specs & Key Tracked Effects (Examples)
+
+*   **Feral Druid**:
+    *   Buffs: Tiger's Fury, Bloodtalons, Prowl, Shadowmeld, Sudden Ambush, Clearcasting.
+    *   DoTs: Rake, Rip, Thrash, Moonfire.
+    *   Talents: Bloodtalons, Moment of Clarity, Carnivorous Instinct, Tiger's Tenacity.
+*   **Assassination Rogue**:
+    *   Buffs: Improved Garrote (talent/legendary).
+    *   DoTs: Garrote.
+
+*(The addon can be extended by defining new `ADS_OPTION_<CLASS>_<SPEC>` tables in its Lua code for other specs.)*
+
+---
+
+# asDotSnapshot
+
+asDotSnapshot은 플레이어가 시전한 지속적인 피해(DoT) 효과의 "스냅샷" 위력을 계산하고 저장하는 월드 오브 워크래프트 유틸리티 애드온입니다. 주로 DoT 피해가 적용 시점의 활성화된 강화 효과에 따라 크게 달라질 수 있는 직업 및 전문화(예: 야성 드루이드, 암살 도적)를 위해 설계되었습니다. 이 애드온 자체는 아무것도 표시하지 않지만, 다른 애드온(예: `asDotFilter`)이 사용할 데이터를 제공합니다.
+
+## 주요 기능
+
+1.  **DoT 스냅샷 계산**:
+    *   플레이어 강화 효과 및 관련 전투 기록 이벤트(`SPELL_AURA_APPLIED`, `SPELL_AURA_REFRESH`, `SPELL_AURA_REMOVED`)를 감시합니다.
+    *   플레이어가 추적된 DoT를 적용하거나 새로고침할 때, 애드온은 해당 순간에 활성화된 강화 효과를 기반으로 피해량 계수를 계산합니다.
+    *   이 계수는 해당 DoT 인스턴스의 "스냅샷된" 강도를 나타냅니다.
+
+2.  **직업 및 전문화별 로직**:
+    *   현재 지원하는 전문화:
+        *   **야성 드루이드**: 호랑이의 분노, 피투성이 발톱, 칼날 발톱/은신 효과(갈퀴 발톱용), 청명의 전조(난타용)와 같은 강화 효과 및 관련 특성을 추적합니다.
+        *   **암살 도적**: 목조르기가 강화된 목조르기 효과와 함께 적용되었는지 추적합니다.
+    *   애드온은 플레이어의 현재 직업 및 전문화에 따라 특정 강화 효과/약화 효과/특성 목록을 로드합니다. 전문화가 명시적으로 지원되지 않는 경우 애드온은 해당 전문화에 대해 휴면 상태를 유지합니다.
+
+3.  **다른 애드온을 위한 데이터 제공자**:
+    *   계산된 스냅샷 값을 전역적으로 저장합니다.
+    *   `asDotSnapshot.Relative(targetGUID, spellId)` 함수를 제공합니다:
+        *   다른 애드온은 이 함수를 호출하여 대상에 현재 활성화된 DoT와 비교하여 새로운 DoT 적용의 상대적인 강도를 얻을 수 있습니다.
+        *   예를 들어, 반환 값 `1.1`은 새로운 적용이 10% 더 강하다는 것을 나타냅니다. 값 `0.9`는 10% 더 약하다는 것을 나타냅니다.
+        *   해당 주문에 대해 대상에 현재 스냅샷된 DoT가 없는 경우, 새로운 시전의 잠재적 위력(예: 호랑이의 분노가 활성화된 경우 `1.15`)을 반환합니다.
+
+4.  **동적 업데이트**:
+    *   플레이어 로그인, 특성 변경 및 능력 설정 업데이트 시 내부 강화 효과 상태 및 특성 정보를 다시 계산합니다.
+    *   `UNIT_AURA` 이벤트를 통해 활성화된 플레이어 강화 효과에 대한 지식을 지속적으로 업데이트합니다.
+
+## 작동 방식
+
+1.  **설정 로드**: 로그인 또는 전문화 변경 시, 플레이어의 직업/전문화와 관련된 미리 정의된 강화 효과, DoT 및 특성 세트를 로드합니다.
+2.  **강화 효과 감시**: 설정된 강화 효과 중 현재 플레이어에게 활성화된 것을 추적합니다.
+3.  **전투 기록 분석**: 플레이어가 대상에게 감시 중인 DoT를 시전하거나 새로고침할 때:
+    *   활성화된 강화 효과를 평가합니다.
+    *   피해량 계수를 계산합니다 (예: 호랑이의 분노가 활성화되어 있으면 계수는 1.15가 될 수 있음).
+    *   이 계수를 해당 특정 대상의 특정 DoT와 연관시켜 저장합니다.
+4.  **데이터 노출**: 다른 애드온은 `asDotSnapshot.Relative()`를 조회하여 DoT를 다시 적용하는 것이 유리한지 결정할 수 있습니다.
+
+## 지원되는 전문화 및 주요 추적 효과 (예시)
+
+*   **야성 드루이드**:
+    *   강화 효과: 호랑이의 분노, 피투성이 발톱, 칼날 발톱, 어둠숨기, 갑작스러운 습격, 청명의 전조.
+    *   DoT: 갈퀴 발톱, 도려내기, 난타, 달빛섬광.
+    *   특성: 피투성이 발톱, 청명의 시간, 육식 본능, 호랑이의 끈기.
+*   **암살 도적**:
+    *   강화 효과: 강화된 목조르기 (특성/전설).
+    *   DoT: 목조르기.
+
+*(애드온의 Lua 코드에 다른 전문화를 위한 새로운 `ADS_OPTION_<CLASS>_<SPEC>` 테이블을 정의하여 확장할 수 있습니다.)*

--- a/asFixChat/README.md
+++ b/asFixChat/README.md
@@ -1,0 +1,67 @@
+# asFixChat
+
+asFixChat is a World of Warcraft addon that enhances chat usability through two main features: smarter chat channel cycling with the Tab key and improved handling of URLs shared in chat.
+
+## Main Features
+
+### 1. Smart Chat Channel Cycling (`asFixChatTab.lua`)
+
+*   **Contextual Tab Cycling**: Modifies the default behavior of the Tab key in the chat input field.
+*   Instead of cycling through all chat channels regardless of context, Tab now intelligently switches to the most relevant available channel based on your current situation:
+    *   **Party**: If in a party (but not a raid).
+    *   **Raid**: If in a raid group.
+    *   **Battleground**: If in a battleground or PvP zone.
+    *   **Guild**: If in a guild and none of the above apply.
+    *   **Instance Chat**: If in a dungeon or instance group (and not raid/battleground).
+    *   **Say**: As a general fallback.
+*   This helps you quickly switch to the desired channel without tabbing through irrelevant ones (e.g., skipping "Party" if you're solo, or "Raid" if not in a raid).
+
+### 2. Enhanced URL Handling (`asFixChatURL.lua`)
+
+*   **Automatic URL Highlighting**: Detects text patterns resembling URLs (e.g., `www.example.com`, `http://example.com`) in incoming chat messages.
+*   **Clickable URL Links**: Transforms detected URLs into clickable, yellow-colored hyperlinks directly within the chat window.
+*   **Easy URL Copying**: When you click one of these highlighted URLs:
+    *   The URL is automatically placed into your chat edit box.
+    *   The text in the edit box is highlighted.
+    *   This allows you to easily copy the URL to your clipboard (using Ctrl+C or Cmd+C) for use outside the game.
+*   This feature simplifies sharing and accessing web links from chat.
+
+## How to Use
+
+*   **Smart Tab Cycling**: Simply press the Tab key while the chat edit box is active. It will cycle through the relevant channels.
+*   **URL Handling**: This feature works automatically. URLs appearing in chat will be highlighted. Click them to populate the edit box for copying.
+
+---
+
+# asFixChat
+
+asFixChat은 두 가지 주요 기능을 통해 채팅 사용성을 향상시키는 월드 오브 워크래프트 애드온입니다: Tab 키를 사용한 스마트한 채팅 채널 순환과 채팅에 공유된 URL 처리 개선입니다.
+
+## 주요 기능
+
+### 1. 스마트 채팅 채널 순환 (`asFixChatTab.lua`)
+
+*   **상황별 Tab 순환**: 채팅 입력창에서 Tab 키의 기본 동작을 수정합니다.
+*   상황에 관계없이 모든 채팅 채널을 순환하는 대신, Tab 키는 이제 현재 상황에 따라 가장 관련성 높은 사용 가능한 채널로 지능적으로 전환합니다:
+    *   **파티**: 파티에 속해 있는 경우 (공격대가 아닌 경우).
+    *   **공격대**: 공격대 그룹에 속해 있는 경우.
+    *   **전장**: 전장 또는 PvP 지역에 있는 경우.
+    *   **길드**: 위의 상황에 해당하지 않고 길드에 속해 있는 경우.
+    *   **인스턴스 대화**: 던전 또는 인스턴스 그룹에 있는 경우 (공격대/전장이 아닌 경우).
+    *   **일반 대화**: 일반적인 기본값.
+*   이를 통해 관련 없는 채널(예: 혼자인 경우 "파티" 건너뛰기, 공격대가 아닌 경우 "공격대" 건너뛰기)을 거치지 않고 원하는 채널로 빠르게 전환할 수 있습니다.
+
+### 2. 향상된 URL 처리 (`asFixChatURL.lua`)
+
+*   **자동 URL 강조**: 들어오는 채팅 메시지에서 URL과 유사한 텍스트 패턴(예: `www.example.com`, `http://example.com`)을 감지합니다.
+*   **클릭 가능한 URL 링크**: 감지된 URL을 채팅 창 내에서 직접 클릭 가능한 노란색 하이퍼링크로 변환합니다.
+*   **간편한 URL 복사**: 강조 표시된 URL 중 하나를 클릭하면:
+    *   URL이 자동으로 채팅 입력창에 배치됩니다.
+    *   입력창의 텍스트가 강조 표시됩니다.
+    *   이를 통해 게임 외부에서 사용하기 위해 URL을 클립보드에 쉽게 복사(Ctrl+C 또는 Cmd+C 사용)할 수 있습니다.
+*   이 기능은 채팅에서 웹 링크를 공유하고 액세스하는 것을 단순화합니다.
+
+## 사용 방법
+
+*   **스마트 Tab 순환**: 채팅 입력창이 활성화된 상태에서 Tab 키를 누르기만 하면 됩니다. 관련 채널을 순환합니다.
+*   **URL 처리**: 이 기능은 자동으로 작동합니다. 채팅에 나타나는 URL이 강조 표시됩니다. 복사를 위해 입력창에 해당 URL을 채우려면 클릭하십시오.

--- a/asFixClearFont/README.md
+++ b/asFixClearFont/README.md
@@ -1,0 +1,57 @@
+# asFixClearFont
+
+asFixClearFont is a small World of Warcraft addon that replaces certain default system number fonts with a custom font ("ClearFont.ttf") included with the addon. This can improve the clarity and readability of numbers in various parts of the UI.
+
+## Main Features
+
+*   **Custom Font Replacement**: Changes the font for several standard Blizzard UI elements that display numbers.
+*   **Targeted Fonts**: Affects UI elements such as:
+    *   `NumberFontNormal`
+    *   `NumberFontNormalYellow`
+    *   `NumberFontNormalSmall`
+    *   `NumberFontNormalSmallGray`
+    *   `NumberFontNormalLarge`
+    *   `NumberFontNormalHuge`
+*   **Included Font**: Comes with "ClearFont.ttf" located in the `Fonts/` subfolder.
+*   **Font Outline**: Applies a standard or thick outline to the replaced fonts for better visibility.
+
+## How it Works
+
+The addon identifies specific predefined "NumberFont" objects within the Blizzard UI and changes their font to "ClearFont.ttf". This is done automatically when the addon is loaded.
+
+## Customization
+
+*   **Font File**: To use a different custom font, you could replace the `Interface\AddOns\asFixClearFont\Fonts\ClearFont.ttf` file with another `.ttf` font file (ensuring it's named `ClearFont.ttf` or by updating the path in `asFixClearFont.lua`).
+*   **Font Scale**: The `asFixClearFont.lua` file contains a `CF_SCALE` variable. While currently set to `1.0` (no change from default sizes), modifying this value could potentially scale the size of the applied custom font, though this would require careful adjustment of the font sizes defined in the Lua file.
+
+**Note**: This addon does not provide an in-game configuration panel.
+
+---
+
+# asFixClearFont
+
+asFixClearFont는 특정 기본 시스템 숫자 글꼴을 애드온에 포함된 사용자 지정 글꼴("ClearFont.ttf")로 대체하는 작은 월드 오브 워크래프트 애드온입니다. 이를 통해 UI 여러 부분의 숫자 명확성과 가독성을 향상시킬 수 있습니다.
+
+## 주요 기능
+
+*   **사용자 지정 글꼴 대체**: 숫자를 표시하는 여러 표준 블리자드 UI 요소의 글꼴을 변경합니다.
+*   **대상 글꼴**: 다음과 같은 UI 요소에 영향을 줍니다:
+    *   `NumberFontNormal`
+    *   `NumberFontNormalYellow`
+    *   `NumberFontNormalSmall`
+    *   `NumberFontNormalSmallGray`
+    *   `NumberFontNormalLarge`
+    *   `NumberFontNormalHuge`
+*   **포함된 글꼴**: `Fonts/` 하위 폴더에 "ClearFont.ttf"가 함께 제공됩니다.
+*   **글꼴 외곽선**: 가시성을 높이기 위해 대체된 글꼴에 표준 또는 굵은 외곽선을 적용합니다.
+
+## 작동 방식
+
+애드온은 블리자드 UI 내에서 미리 정의된 특정 "NumberFont" 객체를 식별하고 해당 글꼴을 "ClearFont.ttf"로 변경합니다. 이는 애드온이 로드될 때 자동으로 수행됩니다.
+
+## 사용자 설정
+
+*   **글꼴 파일**: 다른 사용자 지정 글꼴을 사용하려면 `Interface\AddOns\asFixClearFont\Fonts\ClearFont.ttf` 파일을 다른 `.ttf` 글꼴 파일로 대체할 수 있습니다 (이름을 `ClearFont.ttf`로 지정하거나 `asFixClearFont.lua`에서 경로를 업데이트해야 함).
+*   **글꼴 크기 배율**: `asFixClearFont.lua` 파일에는 `CF_SCALE` 변수가 포함되어 있습니다. 현재 `1.0`(기본 크기에서 변경 없음)으로 설정되어 있지만, 이 값을 수정하면 적용된 사용자 지정 글꼴의 크기를 잠재적으로 조절할 수 있습니다. 다만, 이를 위해서는 Lua 파일에 정의된 글꼴 크기를 신중하게 조정해야 합니다.
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다.

--- a/asFixCombatText/README.md
+++ b/asFixCombatText/README.md
@@ -1,0 +1,73 @@
+# asFixCombatText
+
+asFixCombatText is a World of Warcraft addon that provides customization options for Blizzard's default Floating Combat Text (FCT). It allows users to change the position, scroll behavior, colors, and visibility of certain combat text elements like damage and healing numbers.
+
+## Main Features
+
+*   **Custom Positioning**: Define the starting X and Y coordinates for where combat text appears and how far it scrolls vertically.
+*   **Color Overrides**:
+    *   Sets custom colors for various damage types (physical, spell, damage shield, split damage).
+    *   Customizes colors for "Entering Combat" and "Leaving Combat" messages.
+    *   Allows heal-related combat text (heals, absorbs) to be shown with a specific color, or hidden (controlled by a variable).
+*   **Font Styling**: Sets the combat text font to the standard game font with an outline and a default size of 18.
+*   **Optional Staggering**: Physical damage numbers can be configured to stagger horizontally for a more spread-out appearance.
+*   **Healing Text Visibility**: Provides a toggle (`ASCT_DEFAULT_SHOW_HEAL`) to explicitly show or hide healing-related numbers via this addon's overrides.
+
+## How it Works
+
+The addon modifies Blizzard's internal combat text system:
+1.  It ensures the `enableFloatingCombatText` CVar is active.
+2.  It updates global variables that control combat text font size and height.
+3.  It overrides the `COMBAT_TEXT_TYPE_INFO` table to apply custom colors and show/hide flags for specific event types.
+4.  It sets a custom scroll function (`asCombatText_StandardScroll`) and defines the start/end coordinates for FCT scrolling, effectively fixing the text to a user-defined area of the screen.
+
+## Configuration
+
+Configuration is done by editing Lua variables at the top of the `asFixCombatText/asFixCombatText.lua` file:
+
+*   `ASCT_X_POSITION`: The horizontal (X) screen coordinate where combat text will start. (Default: -250)
+*   `ASCT_Y_POSITION`: The vertical (Y) screen coordinate where combat text will start. (Default: 550)
+*   `ASCT_Y_POSITION_ADDER`: The vertical distance the combat text will scroll upwards. (Default: 200)
+*   `ASCT_STAGGERED`: Set to `true` if you want physical damage numbers to spread out horizontally. Set to `false` for default vertical stacking. (Default: `false`)
+*   `ASCT_DEFAULT_SHOW_HEAL`: Set to `1` if you want healing numbers (heals, absorbs) to be displayed by this addon's color settings. Set to `nil` or any other value to let Blizzard's default settings (or other addons) control their visibility, or hide them if no other system shows them. (Default: `nil`)
+*   `DAMAGE_COLOR`, `SPELL_DAMAGE_COLOR`, etc.: RGB color values for different text types can be adjusted.
+
+**Note**: This addon does not provide an in-game configuration panel. Changes require editing the `.lua` file.
+
+---
+
+# asFixCombatText
+
+asFixCombatText는 블리자드의 기본 전투 상황 알림 텍스트(FCT)에 대한 사용자 설정 옵션을 제공하는 월드 오브 워크래프트 애드온입니다. 사용자는 피해량 및 치유량 숫자와 같은 특정 전투 텍스트 요소의 위치, 스크롤 동작, 색상 및 표시 여부를 변경할 수 있습니다.
+
+## 주요 기능
+
+*   **사용자 지정 위치**: 전투 텍스트가 나타나는 시작 X 및 Y 좌표와 수직으로 스크롤되는 거리를 정의합니다.
+*   **색상 재정의**:
+    *   다양한 피해 유형(물리, 주문, 피해 흡수 보호막, 분산 피해)에 대한 사용자 지정 색상을 설정합니다.
+    *   "전투 시작" 및 "전투 종료" 메시지에 대한 색상을 사용자 지정합니다.
+    *   치유 관련 전투 텍스트(치유, 흡수)를 특정 색상으로 표시하거나 변수를 통해 숨길 수 있도록 허용합니다.
+*   **글꼴 스타일**: 전투 텍스트 글꼴을 외곽선이 있는 표준 게임 글꼴로 설정하고 기본 크기를 18로 지정합니다.
+*   **선택적 시차 표시**: 물리 피해 숫자가 수평으로 약간씩 엇갈리게 표시되도록 설정하여 더 넓게 퍼져 보이게 할 수 있습니다.
+*   **치유 텍스트 표시 여부**: 이 애드온의 재정의를 통해 치유 관련 숫자를 명시적으로 표시하거나 숨길 수 있는 토글(`ASCT_DEFAULT_SHOW_HEAL`)을 제공합니다.
+
+## 작동 방식
+
+애드온은 블리자드의 내부 전투 텍스트 시스템을 수정합니다:
+1.  `enableFloatingCombatText` CVar가 활성화되어 있는지 확인합니다.
+2.  전투 텍스트 글꼴 크기 및 높이를 제어하는 전역 변수를 업데이트합니다.
+3.  특정 이벤트 유형에 대한 사용자 지정 색상 및 표시/숨김 플래그를 적용하기 위해 `COMBAT_TEXT_TYPE_INFO` 테이블을 재정의합니다.
+4.  사용자 지정 스크롤 함수(`asCombatText_StandardScroll`)를 설정하고 FCT 스크롤의 시작/종료 좌표를 정의하여 텍스트를 사용자가 정의한 화면 영역에 효과적으로 고정합니다.
+
+## 설정
+
+설정은 `asFixCombatText/asFixCombatText.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `ASCT_X_POSITION`: 전투 텍스트가 시작될 화면의 가로(X) 좌표입니다. (기본값: -250)
+*   `ASCT_Y_POSITION`: 전투 텍스트가 시작될 화면의 세로(Y) 좌표입니다. (기본값: 550)
+*   `ASCT_Y_POSITION_ADDER`: 전투 텍스트가 위로 스크롤될 세로 거리입니다. (기본값: 200)
+*   `ASCT_STAGGERED`: 물리 피해 숫자가 수평으로 엇갈리게 표시되기를 원하면 `true`로 설정합니다. 기본 수직 중첩의 경우 `false`로 설정합니다. (기본값: `false`)
+*   `ASCT_DEFAULT_SHOW_HEAL`: 이 애드온의 색상 설정에 따라 치유 숫자(치유, 흡수)를 표시하려면 `1`로 설정합니다. 블리자드의 기본 설정(또는 다른 애드온)이 해당 숫자의 표시 여부를 제어하도록 하거나, 다른 시스템에서 표시하지 않는 경우 숨기려면 `nil` 또는 다른 값으로 설정합니다. (기본값: `nil`)
+*   `DAMAGE_COLOR`, `SPELL_DAMAGE_COLOR` 등: 다양한 텍스트 유형에 대한 RGB 색상 값을 조정할 수 있습니다.
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다. 변경하려면 `.lua` 파일을 편집해야 합니다.

--- a/asFixHotkey/README.md
+++ b/asFixHotkey/README.md
@@ -1,0 +1,103 @@
+# asFixHotkey
+
+asFixHotkey is a World of Warcraft addon that customizes the display of hotkey text on action buttons. It aims to provide a more compact and cleaner look by abbreviating long key names and offering an option to hide macro names on buttons.
+
+## Main Features
+
+*   **Abbreviated Hotkey Text**:
+    *   Automatically shortens the text for keybindings displayed on action buttons.
+    *   Examples of abbreviations:
+        *   `Num Pad 1` becomes `1`
+        *   `Middle Mouse` becomes `M3`
+        *   `Mouse Button 4` becomes `M4`
+        *   `Shift-R` becomes `SR`
+        *   `Ctrl-Alt-Delete` becomes `CADt` (approximate, based on logic)
+        *   Arrow keys are represented by symbols like `^`, `V`, `<`, `>`.
+    *   Supports abbreviations for both English and Korean client key names.
+
+*   **Optional Macro Name Hiding**:
+    *   Includes a setting (`ASHK_ShowMacroName` in the Lua file) to control the visibility of macro names on action buttons.
+    *   By default (`false`), macro names are hidden on most standard action bars for a cleaner interface. If set to `true`, macro names will be shown.
+
+*   **Wide Action Bar Coverage**:
+    *   Applies these customizations to most available action bars, including:
+        *   Main action bar
+        *   Multiple Blizzard multi-bars (Bottom Left, Bottom Right, Right, Left)
+        *   Pet bar, Bonus bar, Extra action button, Vehicle UI buttons, Override action bar.
+        *   Additional bars often referred to as MultiBar 5, 6, and 7.
+
+*   **Automatic Updates**:
+    *   Refreshes hotkey displays when the player enters the world or when keybindings are updated.
+
+## How it Works
+
+The addon intercepts the standard hotkey text generation process. For each relevant action button:
+1.  It retrieves the current keybinding.
+2.  It processes the keybinding text through a series of replacement rules to shorten common key names and modifier prefixes.
+3.  It then updates the button's hotkey display region with this new abbreviated text.
+4.  If the option to hide macro names is enabled, it also hides the macro name region on the button.
+
+## Configuration
+
+*   **Show/Hide Macro Names**:
+    *   To change macro name visibility, edit the `ASHK_ShowMacroName` variable at the top of `asFixHotkey/asFixHotkey.lua`.
+        *   `ASHK_ShowMacroName = false;` (Default - hides macro names on most bars)
+        *   `ASHK_ShowMacroName = true;` (Shows macro names)
+
+*   **Hotkey Abbreviations**:
+    *   The specific abbreviations are defined within the `_CheckLongName` function in the Lua file. Advanced users could modify these rules if different abbreviations are desired.
+
+**Note**: This addon does not provide an in-game configuration panel. All customizations require editing the `.lua` file.
+
+---
+
+# asFixHotkey
+
+asFixHotkey는 액션 버튼에 표시되는 단축키 텍스트의 표시 방식을 사용자 정의하는 월드 오브 워크래프트 애드온입니다. 긴 키 이름을 축약하고 버튼의 매크로 이름을 숨기는 옵션을 제공하여 더 간결하고 깔끔한 외관을 제공하는 것을 목표로 합니다.
+
+## 주요 기능
+
+*   **단축키 텍스트 축약**:
+    *   액션 버튼에 표시되는 키 바인딩 텍스트를 자동으로 줄여줍니다.
+    *   축약 예시:
+        *   `Num Pad 1` (숫자패드 1)은 `1`로 변경
+        *   `Middle Mouse` (마우스 가운데 버튼)는 `M3`로 변경
+        *   `Mouse Button 4` (4번 마우스 버튼)는 `M4`로 변경
+        *   `Shift-R`은 `SR`로 변경
+        *   `Ctrl-Alt-Delete`는 대략 `CADt`로 변경 (로직 기반)
+        *   화살표 키는 `^`, `V`, `<`, `>`와 같은 기호로 표시됩니다.
+    *   영어 및 한국어 클라이언트의 키 이름 모두에 대한 축약을 지원합니다.
+
+*   **매크로 이름 숨기기 (선택 사항)**:
+    *   Lua 파일 내의 설정 (`ASHK_ShowMacroName`)을 통해 액션 버튼의 매크로 이름 표시 여부를 제어합니다.
+    *   기본값 (`false`)에서는 더 깔끔한 인터페이스를 위해 대부분의 표준 액션 바에서 매크로 이름이 숨겨집니다. `true`로 설정하면 매크로 이름이 표시됩니다.
+
+*   **광범위한 액션 바 지원**:
+    *   다음과 같은 대부분의 사용 가능한 액션 바에 이러한 사용자 정의를 적용합니다:
+        *   주 액션 바
+        *   여러 블리자드 멀티바 (하단 좌측, 하단 우측, 우측, 좌측)
+        *   소환수 바, 보너스 바, 추가 액션 버튼, 차량 UI 버튼, 우선 지정 액션 바.
+        *   흔히 멀티바 5, 6, 7로 불리는 추가 바.
+
+*   **자동 업데이트**:
+    *   플레이어가 게임 세계에 접속하거나 키 바인딩이 업데이트될 때 단축키 표시를 새로고침합니다.
+
+## 작동 방식
+
+애드온은 표준 단축키 텍스트 생성 프로세스를 가로챕니다. 각 관련 액션 버튼에 대해:
+1.  현재 키 바인딩을 가져옵니다.
+2.  일련의 대체 규칙을 통해 키 바인딩 텍스트를 처리하여 일반적인 키 이름과 수식어 접두사를 줄입니다.
+3.  그런 다음 이 새로운 축약된 텍스트로 버튼의 단축키 표시 영역을 업데이트합니다.
+4.  매크로 이름 숨기기 옵션이 활성화된 경우 버튼의 매크로 이름 영역도 숨깁니다.
+
+## 설정
+
+*   **매크로 이름 표시/숨기기**:
+    *   매크로 이름 표시 여부를 변경하려면 `asFixHotkey/asFixHotkey.lua` 파일 상단의 `ASHK_ShowMacroName` 변수를 편집하십시오.
+        *   `ASHK_ShowMacroName = false;` (기본값 - 대부분의 바에서 매크로 이름 숨김)
+        *   `ASHK_ShowMacroName = true;` (매크로 이름 표시)
+
+*   **단축키 축약**:
+    *   특정 축약형은 Lua 파일의 `_CheckLongName` 함수 내에 정의되어 있습니다. 고급 사용자는 다른 축약형을 원할 경우 이러한 규칙을 수정할 수 있습니다.
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다. 모든 사용자 정의는 `.lua` 파일을 편집해야 합니다.

--- a/asFixUnitFrame/README.md
+++ b/asFixUnitFrame/README.md
@@ -1,0 +1,79 @@
+# asFixUnitFrame
+
+asFixUnitFrame is a World of Warcraft addon that provides a collection of optional tweaks to the default Blizzard unit frames (Player, Target, TargetofTarget). It also includes a unique feature to display a single, high-priority debuff directly on the target's portrait. Many features are configurable through the in-game addon settings menu.
+
+## Main Features
+
+*   **Optional Unit Frame Modifications (Configurable via Addon Settings)**:
+    *   **Hide Combat Text on Frames**: Option to prevent Blizzard's default floating combat text from appearing directly on the Player, Target, and Pet unit frames.
+    *   **Hide Target's Buffs/Debuffs**: Option to remove the standard buff and debuff icons from the Target unit frame.
+    *   **Hide Target's Cast Bar**: Option to conceal the cast bar on the Target unit frame.
+    *   **Hide Player's Class Bar**: Option to hide the special class resource displays (e.g., Rogue Combo Points, Death Knight Runes, Evoker Essence, Shaman Totem Bar).
+    *   **Show Numeric Threat**: Option to enable or disable the display of numerical threat values on unit frames (sets the `threatShowNumeric` CVar).
+    *   **Class Color Health Bars**: Option to color the health bars of Player, Target, and TargetofTarget frames according to the unit's class (if they are a player).
+
+*   **Target Portrait Debuff Display (`ShowPortraitDebuff` option)**:
+    *   If enabled, displays a single, filtered debuff icon directly overlaid on the Target's portrait.
+    *   **Filtering Logic**: Shows a harmful debuff that is flagged as `nameplateShowAll` (generally important) and has a duration of 10 seconds or less.
+    *   It has a secondary filter (`ns.ShowOnlyMine`) to avoid showing certain common player-applied debuffs on the portrait if they weren't cast by the current player (aiming to highlight external, high-priority debuffs).
+    *   The icon includes a circular cooldown swipe indicating remaining duration.
+    *   Provides a tooltip on mouseover for the displayed debuff.
+
+*   **Conditional Loading**: The addon checks if "asUnitFrame" (presumably a more comprehensive unit frame addon from the same author/suite) is loaded. If it is, `asFixUnitFrame` will not initialize its main features to prevent conflicts.
+
+## Configuration
+
+Most features can be toggled via the Blizzard Addon Settings panel:
+1.  Open Game Menu (Esc).
+2.  Click "Options".
+3.  Go to the "AddOns" tab.
+4.  Select "asFixUnitFrame" from the list.
+5.  Adjust the checkbox settings as desired.
+    *   **Note**: Changing these settings requires a `ReloadUI()` to take effect, which the game will prompt you for.
+
+Advanced configuration or modification of the `ns.ShowOnlyMine` list requires editing the `asFixUnitFrame/asFixUnitFrameOption.lua` file.
+
+Key internal variables affecting behavior:
+*   `CONFIG_MAX_COOL` (in `asFixUnitFrame.lua`): Hardcoded to 10 seconds, determining the maximum duration for a debuff to be considered for the portrait display.
+*   `ns.options.*` (populated from saved variables or defaults in `asFixUnitFrameOption.lua`): These hold the state of the toggleable features.
+
+---
+
+# asFixUnitFrame
+
+asFixUnitFrame은 블리자드 기본 유닛 프레임(플레이어, 대상, 대상의 대상)에 대한 여러 선택적 조정을 제공하는 월드 오브 워크래프트 애드온입니다. 또한 대상의 초상화에 단일의 우선순위가 높은 디버프를 직접 표시하는 독특한 기능을 포함합니다. 대부분의 기능은 게임 내 애드온 설정 메뉴를 통해 설정할 수 있습니다.
+
+## 주요 기능
+
+*   **선택적 유닛 프레임 수정 (애드온 설정을 통해 구성 가능)**:
+    *   **프레임 위 전투 텍스트 숨기기**: 플레이어, 대상 및 소환수 유닛 프레임에 블리자드 기본 전투 상황 알림 텍스트가 직접 나타나지 않도록 하는 옵션입니다.
+    *   **대상의 버프/디버프 숨기기**: 대상 유닛 프레임에서 표준 버프 및 디버프 아이콘을 제거하는 옵션입니다.
+    *   **대상의 시전바 숨기기**: 대상 유닛 프레임의 시전바를 숨기는 옵션입니다.
+    *   **플레이어 직업 바 숨기기**: 특수 직업 자원 표시(예: 도적 연계 점수, 죽음의 기사 룬, 기원사 정수, 주술사 토템 바)를 숨기는 옵션입니다.
+    *   **숫자 위협 수준 표시**: 유닛 프레임에 숫자 위협 수준 표시를 활성화하거나 비활성화하는 옵션입니다 (`threatShowNumeric` CVar 설정).
+    *   **직업 색상 생명력 바**: 플레이어, 대상 및 대상의 대상 프레임의 생명력 바를 유닛의 직업(플레이어인 경우)에 따라 색칠하는 옵션입니다.
+
+*   **대상 초상화 디버프 표시 (`ShowPortraitDebuff` 옵션)**:
+    *   활성화된 경우, 대상의 초상화에 직접 오버레이된 단일 필터링된 디버프 아이콘을 표시합니다.
+    *   **필터링 로직**: `nameplateShowAll`(일반적으로 중요함)로 플래그 지정되고 지속 시간이 10초 이하인 해로운 디버프를 표시합니다.
+    *   특정 일반적인 플레이어 적용 디버프가 현재 플레이어가 시전하지 않은 경우 초상화에 표시되지 않도록 하는 보조 필터(`ns.ShowOnlyMine`)가 있습니다 (외부의 우선순위 높은 디버프를 강조하기 위함).
+    *   아이콘에는 남은 지속 시간을 나타내는 원형 재사용 대기시간 효과가 포함됩니다.
+    *   표시된 디버프에 마우스를 올리면 툴팁을 제공합니다.
+
+*   **조건부 로딩**: 애드온은 "asUnitFrame"(아마도 동일한 제작자/제품군의 더 포괄적인 유닛 프레임 애드온)이 로드되었는지 확인합니다. 로드된 경우 `asFixUnitFrame`은 충돌을 방지하기 위해 주요 기능을 초기화하지 않습니다.
+
+## 설정
+
+대부분의 기능은 블리자드 애드온 설정 패널을 통해 전환할 수 있습니다:
+1.  게임 메뉴(Esc)를 엽니다.
+2.  "설정"을 클릭합니다.
+3.  "애드온" 탭으로 이동합니다.
+4.  목록에서 "asFixUnitFrame"을 선택합니다.
+5.  원하는 대로 확인란 설정을 조정합니다.
+    *   **참고**: 이러한 설정을 변경하면 `ReloadUI()`가 필요하며, 게임에서 이를 요청하는 메시지가 표시됩니다.
+
+`ns.ShowOnlyMine` 목록의 고급 설정 또는 수정은 `asFixUnitFrame/asFixUnitFrameOption.lua` 파일을 편집해야 합니다.
+
+동작에 영향을 미치는 주요 내부 변수:
+*   `CONFIG_MAX_COOL` (`asFixUnitFrame.lua` 내): 10초로 하드코딩되어 있으며, 초상화 표시에 고려될 디버프의 최대 지속 시간을 결정합니다.
+*   `ns.options.*` (`asFixUnitFrameOption.lua`의 저장된 변수 또는 기본값에서 채워짐): 전환 가능한 기능의 상태를 유지합니다.

--- a/asGCDBar/README.md
+++ b/asGCDBar/README.md
@@ -1,0 +1,67 @@
+# asGCDBar
+
+asGCDBar is a World of Warcraft addon that displays a simple status bar to visualize the player's Global Cooldown (GCD).
+
+## Main Features
+
+*   **Visual GCD Indicator**: Shows a customizable bar that fills up during the Global Cooldown, providing a clear visual cue for when your next action can be taken.
+*   **Customizable Appearance**: The width, height, and on-screen position of the GCD bar can be adjusted by editing variables in the Lua file.
+*   **asMOD Integration**: If the `asMOD` addon is installed, `asGCDBar` can integrate with it, allowing its position to be managed and saved through `asMOD`'s configuration interface.
+*   **Simple Design**: Uses a clean bar with a background texture for a border effect.
+
+## How it Works
+
+1.  The addon creates a `StatusBar` element.
+2.  It periodically checks the player's Global Cooldown status using `C_Spell.GetSpellCooldown(61304)`. (Spell ID 61304 is commonly used to track GCD).
+3.  When the GCD is active, the bar animates from empty to full over the duration of the GCD.
+4.  When the GCD is not active, the bar is hidden.
+
+## Configuration
+
+Basic configuration is done by editing variables at the top of `asGCDBar/asGCDBar.lua`:
+
+*   `AGCDB_WIDTH`: Sets the width of the GCD bar in pixels. (Default: 196)
+*   `AGCDB_HEIGHT`: Sets the height of the GCD bar in pixels. (Default: 5)
+*   `AGCDB_X`: The horizontal (X) offset from the center of the screen. (Default: 0)
+*   `AGCDB_Y`: The vertical (Y) offset from the center of the screen. (Default: -284, typically placing it below the center)
+
+The bar's color can also be changed by modifying the `SetStatusBarColor(1, 0.9, 0.9)` line in the Lua file (RGB values).
+
+If `asMOD` is installed, the position of the bar can be more easily adjusted and saved using `asMOD`'s `/asConfig` command or similar interface.
+
+**Note**: This addon does not provide an in-game configuration panel for these settings without `asMOD`.
+
+---
+
+# asGCDBar
+
+asGCDBar는 플레이어의 전역 재사용 대기시간(GCD)을 시각화하는 간단한 상태 바를 표시하는 월드 오브 워크래프트 애드온입니다.
+
+## 주요 기능
+
+*   **시각적 GCD 표시기**: 전역 재사용 대기시간 동안 채워지는 사용자 정의 가능한 바를 표시하여 다음 행동을 언제 할 수 있는지 명확한 시각적 신호를 제공합니다.
+*   **사용자 정의 가능한 외형**: Lua 파일의 변수를 편집하여 GCD 바의 너비, 높이 및 화면 위치를 조정할 수 있습니다.
+*   **asMOD 연동**: `asMOD` 애드온이 설치된 경우, `asGCDBar`는 이와 연동하여 `asMOD`의 설정 인터페이스를 통해 위치를 관리하고 저장할 수 있도록 합니다.
+*   **심플한 디자인**: 테두리 효과를 위한 배경 텍스처가 있는 깔끔한 바를 사용합니다.
+
+## 작동 방식
+
+1.  애드온은 `StatusBar` 요소를 생성합니다.
+2.  `C_Spell.GetSpellCooldown(61304)`를 사용하여 주기적으로 플레이어의 전역 재사용 대기시간 상태를 확인합니다. (주문 ID 61304는 GCD를 추적하는 데 일반적으로 사용됩니다).
+3.  GCD가 활성화되면 바는 GCD 지속 시간 동안 비어 있는 상태에서 가득 찬 상태로 애니메이션됩니다.
+4.  GCD가 활성화되지 않으면 바는 숨겨집니다.
+
+## 설정
+
+기본 설정은 `asGCDBar/asGCDBar.lua` 파일 상단의 변수를 편집하여 수행합니다:
+
+*   `AGCDB_WIDTH`: GCD 바의 너비를 픽셀 단위로 설정합니다. (기본값: 196)
+*   `AGCDB_HEIGHT`: GCD 바의 높이를 픽셀 단위로 설정합니다. (기본값: 5)
+*   `AGCDB_X`: 화면 중앙으로부터의 가로(X) 오프셋입니다. (기본값: 0)
+*   `AGCDB_Y`: 화면 중앙으로부터의 세로(Y) 오프셋입니다. (기본값: -284, 일반적으로 중앙 아래에 위치)
+
+바의 색상은 Lua 파일의 `SetStatusBarColor(1, 0.9, 0.9)` 줄을 수정하여 변경할 수도 있습니다 (RGB 값).
+
+`asMOD`가 설치된 경우, `asMOD`의 `/asConfig` 명령 또는 유사한 인터페이스를 사용하여 바의 위치를 더 쉽게 조정하고 저장할 수 있습니다.
+
+**참고**: 이 애드온은 `asMOD` 없이는 이러한 설정을 위한 게임 내 설정 패널을 제공하지 않습니다.

--- a/asGearScoreLite/README.md
+++ b/asGearScoreLite/README.md
@@ -1,0 +1,69 @@
+# asGearScoreLite
+
+asGearScoreLite is a lightweight World of Warcraft addon that displays item levels directly on your Character Frame and the Inspect Frame. It also calculates and shows the average item level for inspected targets.
+
+## Main Features
+
+*   **Individual Item Level Display**:
+    *   **Character Frame**: Shows the item level of each piece of your equipped gear directly on the item slots in your Character Pane (C). The text is colored according to item quality (e.g., Epic, Rare).
+    *   **Inspect Frame**: When inspecting another player, displays the item level of each piece of their equipped gear on their respective item slots, also colored by quality.
+
+*   **Average Item Level for Target**:
+    *   When you inspect another player, their average item level is calculated and displayed prominently on the Inspect Frame (e.g., "450 Lvl").
+    *   The calculation correctly weights two-handed weapons by counting them effectively as two slots to provide an accurate average.
+
+*   **Tooltip-Based Item Level Detection**:
+    *   Uses a temporary tooltip to scan item information and retrieve the item level, ensuring compatibility even if item data structures change.
+
+*   **Dynamic Updates**:
+    *   Player's item levels on the Character Frame update when equipment is changed.
+    *   Target's item levels and average item level update when the Inspect Frame is shown.
+
+## How it Works
+
+1.  **Character Frame**: When your Character Frame is opened or your gear changes, the addon iterates through your equipment slots, creates small text overlays on each slot, and displays the item level (colored by quality) obtained by scanning the item's tooltip.
+2.  **Inspect Frame**: When you inspect another player, a similar process occurs for their gear. Additionally, an average item level is calculated. This average considers all equipped slots and gives appropriate weight to two-handed weapons. The average is then displayed in a dedicated text field on the Inspect Frame.
+
+## Configuration
+
+*   **Font Size**:
+    *   The font size for the individual item level text can be adjusted by changing the `AGS_FontSize` variable at the top of `asGearScoreLite/asGearScoreLite.lua`. The default is `11`.
+    *   The average item level display on the inspect frame uses `AGS_FontSize + 2`.
+
+**Note**: This addon does not provide an in-game configuration panel. Customization of font size requires editing the `.lua` file.
+
+---
+
+# asGearScoreLite
+
+asGearScoreLite는 자신의 캐릭터 창 및 살펴보기 창에 아이템 레벨을 직접 표시하는 가벼운 월드 오브 워크래프트 애드온입니다. 또한 살펴본 대상의 평균 아이템 레벨을 계산하여 표시합니다.
+
+## 주요 기능
+
+*   **개별 아이템 레벨 표시**:
+    *   **캐릭터 창**: 자신의 캐릭터 창(C)에 있는 각 착용 장비의 아이템 레벨을 해당 아이템 슬롯에 직접 표시합니다. 텍스트는 아이템 등급(예: 영웅, 희귀)에 따라 색상이 지정됩니다.
+    *   **살펴보기 창**: 다른 플레이어를 살펴볼 때, 해당 플레이어가 착용한 각 장비의 아이템 레벨을 각 아이템 슬롯에 등급별 색상으로 표시합니다.
+
+*   **대상의 평균 아이템 레벨**:
+    *   다른 플레이어를 살펴볼 때, 해당 플레이어의 평균 아이템 레벨이 계산되어 살펴보기 창에 눈에 띄게 표시됩니다 (예: "450 Lvl").
+    *   계산 시 양손 무기는 정확한 평균을 제공하기 위해 효과적으로 두 개의 슬롯으로 계산하여 적절한 가중치를 부여합니다.
+
+*   **툴팁 기반 아이템 레벨 감지**:
+    *   임시 툴팁을 사용하여 아이템 정보를 스캔하고 아이템 레벨을 가져오므로, 아이템 데이터 구조가 변경되더라도 호환성을 보장합니다.
+
+*   **동적 업데이트**:
+    *   캐릭터 창의 플레이어 아이템 레벨은 장비가 변경될 때 업데이트됩니다.
+    *   대상의 아이템 레벨 및 평균 아이템 레벨은 살펴보기 창이 표시될 때 업데이트됩니다.
+
+## 작동 방식
+
+1.  **캐릭터 창**: 캐릭터 창을 열거나 장비를 변경하면, 애드온은 장비 슬롯을 반복하면서 각 슬롯에 작은 텍스트 오버레이를 만들고 아이템 툴팁을 스캔하여 얻은 아이템 레벨(등급별 색상)을 표시합니다.
+2.  **살펴보기 창**: 다른 플레이어를 살펴보면 해당 플레이어의 장비에 대해서도 유사한 프로세스가 발생합니다. 추가적으로 평균 아이템 레벨이 계산됩니다. 이 평균은 모든 착용 슬롯을 고려하며 양손 무기에 적절한 가중치를 부여합니다. 그런 다음 평균값은 살펴보기 창의 전용 텍스트 필드에 표시됩니다.
+
+## 설정
+
+*   **글꼴 크기**:
+    *   개별 아이템 레벨 텍스트의 글꼴 크기는 `asGearScoreLite/asGearScoreLite.lua` 파일 상단의 `AGS_FontSize` 변수를 변경하여 조정할 수 있습니다. 기본값은 `11`입니다.
+    *   살펴보기 창의 평균 아이템 레벨 표시는 `AGS_FontSize + 2`를 사용합니다.
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다. 글꼴 크기 사용자 정의는 `.lua` 파일을 편집해야 합니다.

--- a/asHealerChatAlert/README.md
+++ b/asHealerChatAlert/README.md
@@ -1,0 +1,77 @@
+# asHealerChatAlert
+
+asHealerChatAlert is a World of Warcraft addon that automatically announces the party healer's mana percentage in chat if it falls below a configurable threshold when exiting combat inside an instance.
+
+## Main Features
+
+*   **Automatic Mana Reporting**: When a group is in an instance and exits combat, the addon checks the designated healer's mana.
+*   **Configurable Threshold**: If the healer's mana is below a user-defined percentage, a message like "힐러마나 [X]%" (Healer mana [X]%) is sent to the current chat channel (typically party chat).
+*   **Healer Detection**:
+    *   In a 5-man party, it identifies the party member assigned the "HEALER" role.
+    *   If the player themself is the healer, it tracks their mana.
+    *   The addon is generally inactive in raids or when solo.
+*   **In-Game Configuration**: Options can be configured through the Blizzard Addon Settings panel.
+
+## How it Works
+
+1.  **Healer Identification**: On events like joining a group, role changes, or entering the world, the addon identifies the healer in a 5-man party.
+2.  **Combat Exit Trigger**: When the `PLAYER_REGEN_ENABLED` event fires (signifying the group has likely left combat) and the group is in an instance:
+    *   It checks the identified healer's current mana percentage.
+    *   If this percentage is below the configured `AnnounceMana` threshold, it sends the alert message.
+
+## Configuration
+
+Settings can be accessed via the Blizzard Addon Settings panel:
+1.  Open Game Menu (Esc).
+2.  Click "Options".
+3.  Go to the "AddOns" tab.
+4.  Select "asHealthChatAlert" (Note: The settings panel might be listed under this slightly different name).
+5.  Adjust the following:
+    *   **`AlertAnyway` (Checkbox)**:
+        *   `false` (Default): The addon primarily functions if there's a clear healer in a 5-man party.
+        *   `true`: The addon may attempt to announce mana more broadly, though its core logic is still oriented towards a single party healer.
+    *   **`AnnounceMana` (Slider)**:
+        *   Sets the mana percentage threshold below which an alert is triggered.
+        *   Range: 0% to 100%. (Default: 50%)
+
+Changes to these settings are saved per character and typically take effect immediately or upon the next relevant game event.
+
+---
+
+# asHealerChatAlert
+
+asHealerChatAlert는 월드 오브 워크래프트 애드온으로, 인스턴스 내에서 전투가 종료될 때 파티 힐러의 마나가 설정된 임계값 아래로 떨어지면 자동으로 파티 채팅으로 알려줍니다.
+
+## 주요 기능
+
+*   **자동 마나 보고**: 그룹이 인스턴스에 있고 전투에서 벗어나면 애드온은 지정된 힐러의 마나를 확인합니다.
+*   **설정 가능한 임계값**: 힐러의 마나가 사용자가 정의한 백분율 미만이면 "힐러마나 [X]%"와 같은 메시지가 현재 채팅 채널(일반적으로 파티 채팅)로 전송됩니다.
+*   **힐러 감지**:
+    *   5인 파티에서 "HEALER" 역할을 맡은 파티원을 식별합니다.
+    *   플레이어 자신이 힐러인 경우 자신의 마나를 추적합니다.
+    *   애드온은 일반적으로 공격대 또는 솔로 플레이 시에는 비활성화됩니다.
+*   **게임 내 설정**: 블리자드 애드온 설정 패널을 통해 옵션을 구성할 수 있습니다.
+
+## 작동 방식
+
+1.  **힐러 식별**: 그룹 가입, 역할 변경 또는 게임 세계 접속과 같은 이벤트 발생 시, 애드온은 5인 파티의 힐러를 식별합니다.
+2.  **전투 종료 트리거**: `PLAYER_REGEN_ENABLED` 이벤트(그룹이 전투에서 벗어났음을 의미)가 발생하고 그룹이 인스턴스에 있을 때:
+    *   식별된 힐러의 현재 마나 백분율을 확인합니다.
+    *   이 백분율이 설정된 `AnnounceMana` 임계값 미만이면 알림 메시지를 보냅니다.
+
+## 설정
+
+설정은 블리자드 애드온 설정 패널을 통해 접근할 수 있습니다:
+1.  게임 메뉴(Esc)를 엽니다.
+2.  "설정"을 클릭합니다.
+3.  "애드온" 탭으로 이동합니다.
+4.  목록에서 "asHealthChatAlert"를 선택합니다 (참고: 설정 패널 이름이 약간 다를 수 있습니다).
+5.  다음을 조정합니다:
+    *   **`AlertAnyway` (체크박스)**:
+        *   `false` (기본값): 애드온은 주로 5인 파티에 명확한 힐러가 있을 경우 작동합니다.
+        *   `true`: 애드온이 더 광범위하게 마나를 알리려고 시도할 수 있지만, 핵심 로직은 여전히 단일 파티 힐러를 대상으로 합니다.
+    *   **`AnnounceMana` (슬라이더)**:
+        *   알림이 발생하는 마나 백분율 임계값을 설정합니다.
+        *   범위: 0% ~ 100%. (기본값: 50%)
+
+이러한 설정 변경 사항은 캐릭터별로 저장되며 일반적으로 즉시 또는 다음 관련 게임 이벤트 시 적용됩니다.

--- a/asHealthText/README.md
+++ b/asHealthText/README.md
@@ -1,0 +1,129 @@
+# asHealthText
+
+asHealthText is a World of Warcraft addon that displays a customizable, text-based Head-Up Display (HUD) for crucial combat information. It shows health and resource percentages for the player, target, and pet, along with threat, incoming heals, and class-specific resources.
+
+## Main Features
+
+*   **Text-Based Information Hub**:
+    *   **Player Stats**: Health % and Mana/Power %.
+    *   **Target Stats**: Health % (class-colored if player) and Mana/Power %.
+    *   **Pet Stats**: Health % and Mana/Power %.
+    *   **Threat Display**: Current threat percentage on the target, colored by status.
+    *   **Target's Target**: Name of your target's target, class-colored.
+    *   **Incoming Heals & Absorbs**: Shows predicted health % after incoming heals, and/or current absorb % on the player.
+    *   **Raid Icon**: Displays the raid target icon set on your current target.
+    *   **Class-Specific Resources**:
+        *   Death Knight: Rune count.
+        *   Paladin: Holy Power.
+        *   Warlock: Soul Shards.
+        *   Druid (Feral/Guardian): Combo Points.
+        *   Rogue: Combo Points.
+        *   Monk (Brewmaster): Stagger percentage.
+        *   Monk (Windwalker/Mistweaver): Chi.
+        *   Mage (Arcane): Arcane Charges.
+        *   Evoker: Essence.
+        *   *(Note: Class resource display is disabled if the `asPowerBar` addon is loaded).*
+
+*   **Customizable Appearance**:
+    *   Font, font sizes (for health, mana, pet text separately), and font outline can be configured.
+    *   Dynamic color-coding for health (green to red), mana (by resource type), and threat.
+
+*   **Layout Configuration**:
+    *   The entire block of text can be positioned using X/Y offsets.
+    *   An option (`AHT_RIGHT_COMBO`) alters the relative placement of class resources, raid icons, and pet information.
+
+*   **Combat Visibility**:
+    *   The display is typically shown upon entering combat and hidden when leaving combat.
+    *   An option (`AHT_COMBAT_OFF_SHOW`) allows the display to remain visible even out of combat.
+
+*   **Vehicle Support**: Attempts to display vehicle health/power when the player is controlling a vehicle.
+
+## How it Works
+
+The addon creates a series of configurable font strings anchored to a central (hidden) frame. It then populates these font strings with data obtained from various game API functions, updating them in response to relevant game events (e.g., health changes, target changes, combat status) and a periodic timer. Class-specific resource tracking is enabled based on the player's class and specialization, and is disabled if `asPowerBar` is active.
+
+## Configuration
+
+Configuration is done by editing Lua variables at the top of `asHealthText/asHealthText.lua`:
+
+*   `AHT_Font`: The font face to be used. (Default: `STANDARD_TEXT_FONT`)
+*   `AHT_HealthSize`: Font size for player and target health percentages. (Default: 18)
+*   `AHT_ManaSize`: Font size for player and target mana/power percentages and threat. (Default: 14)
+*   `AHT_PetHealthSize`: Font size for pet health percentage. (Default: 12)
+*   `AHT_PetManaSize`: Font size for pet mana/power percentage. (Default: 10)
+*   `AHT_FontOutline`: Font outline style (e.g., "THICKOUTLINE", "OUTLINE"). (Default: "THICKOUTLINE")
+*   `AHT_X`: Horizontal offset for the text block from the center of the screen. (Default: 150, placing target info to the right)
+*   `AHT_Y`: Vertical offset for the text block from the center of the screen. (Default: -55, placing it below center)
+*   `AHT_COMBAT_OFF_SHOW`: Set to `true` to keep the display visible out of combat. (Default: `false`)
+*   `AHT_RIGHT_COMBO`: Set to `true` to change the layout of class resources, raid icon, and pet info relative to player/target health. (Default: `false`)
+
+Internal variables that can be toggled (requiring Lua edit):
+*   `bupdate_heal`: Set to `false` to disable incoming heal/absorb display. (Default: `true`)
+
+**Note**: This addon does not provide an in-game configuration panel.
+
+---
+
+# asHealthText
+
+asHealthText는 중요한 전투 정보를 위한 사용자 정의 가능한 텍스트 기반 HUD(Head-Up Display)를 표시하는 월드 오브 워크래프트 애드온입니다. 플레이어, 대상 및 소환수의 생명력 및 자원 백분율을 위협 수준, 받는 치유량, 직업별 자원과 함께 보여줍니다.
+
+## 주요 기능
+
+*   **텍스트 기반 정보 허브**:
+    *   **플레이어 능력치**: 생명력 % 및 마나/기력 %.
+    *   **대상 능력치**: 생명력 % (플레이어인 경우 직업 색상) 및 마나/기력 %.
+    *   **소환수 능력치**: 생명력 % 및 마나/기력 %.
+    *   **위협 수준 표시**: 대상에 대한 현재 위협 수준 백분율을 상태별 색상으로 표시합니다.
+    *   **대상의 대상**: 대상의 대상 이름을 직업 색상으로 표시합니다.
+    *   **받는 치유량 및 흡수량**: 플레이어에게 들어오는 치유량을 포함한 예상 생명력 % 및/또는 현재 흡수량 %를 표시합니다.
+    *   **공격대 아이콘**: 현재 대상에게 설정된 공격대 대상 아이콘을 표시합니다.
+    *   **직업별 자원**:
+        *   죽음의 기사: 룬 개수.
+        *   성기사: 신성한 힘.
+        *   흑마법사: 영혼의 조각.
+        *   드루이드 (야성/수호): 연계 점수.
+        *   도적: 연계 점수.
+        *   수도사 (양조): 시간차 피해량 백분율.
+        *   수도사 (풍운/운무): 기.
+        *   마법사 (비전): 비전 충전물.
+        *   기원사: 정수.
+        *   *(참고: `asPowerBar` 애드온이 로드된 경우 직업 자원 표시는 비활성화됩니다.)*
+
+*   **사용자 정의 가능한 외형**:
+    *   글꼴, 글꼴 크기(생명력, 마나, 소환수 텍스트 각각), 글꼴 외곽선을 설정할 수 있습니다.
+    *   생명력(녹색에서 빨간색으로), 마나(자원 유형별), 위협 수준에 대한 동적 색상 코딩.
+
+*   **레이아웃 설정**:
+    *   전체 텍스트 블록은 X/Y 오프셋을 사용하여 위치를 지정할 수 있습니다.
+    *   `AHT_RIGHT_COMBO` 옵션은 직업 자원, 공격대 아이콘 및 소환수 정보의 상대적 배치를 변경합니다.
+
+*   **전투 중 표시 여부**:
+    *   디스플레이는 일반적으로 전투에 진입하면 표시되고 전투에서 벗어나면 숨겨집니다.
+    *   `AHT_COMBAT_OFF_SHOW` 옵션을 사용하면 전투 중이 아닐 때도 디스플레이를 계속 볼 수 있습니다.
+
+*   **차량 지원**: 플레이어가 차량을 제어할 때 차량의 생명력/자원을 표시하려고 시도합니다.
+
+## 작동 방식
+
+애드온은 중앙(숨겨진) 프레임에 고정된 일련의 설정 가능한 글꼴 문자열을 만듭니다. 그런 다음 다양한 게임 API 함수에서 얻은 데이터로 이러한 글꼴 문자열을 채우고, 관련 게임 이벤트(예: 생명력 변경, 대상 변경, 전투 상태) 및 주기적인 타이머에 응답하여 업데이트합니다. 직업별 자원 추적은 플레이어의 직업 및 전문화에 따라 활성화되며, `asPowerBar`가 활성화된 경우 비활성화됩니다.
+
+## 설정
+
+설정은 `asHealthText/asHealthText.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `AHT_Font`: 사용할 글꼴입니다. (기본값: `STANDARD_TEXT_FONT`)
+*   `AHT_HealthSize`: 플레이어 및 대상 생명력 백분율의 글꼴 크기입니다. (기본값: 18)
+*   `AHT_ManaSize`: 플레이어 및 대상 마나/기력 백분율 및 위협 수준의 글꼴 크기입니다. (기본값: 14)
+*   `AHT_PetHealthSize`: 소환수 생명력 백분율의 글꼴 크기입니다. (기본값: 12)
+*   `AHT_PetManaSize`: 소환수 마나/기력 백분율의 글꼴 크기입니다. (기본값: 10)
+*   `AHT_FontOutline`: 글꼴 외곽선 스타일입니다 (예: "THICKOUTLINE", "OUTLINE"). (기본값: "THICKOUTLINE")
+*   `AHT_X`: 화면 중앙에서 텍스트 블록의 가로 오프셋입니다. (기본값: 150, 대상 정보를 오른쪽에 배치)
+*   `AHT_Y`: 화면 중앙에서 텍스트 블록의 세로 오프셋입니다. (기본값: -55, 중앙 아래에 배치)
+*   `AHT_COMBAT_OFF_SHOW`: 전투 중이 아닐 때 디스플레이를 계속 표시하려면 `true`로 설정합니다. (기본값: `false`)
+*   `AHT_RIGHT_COMBO`: 직업 자원, 공격대 아이콘 및 소환수 정보의 레이아웃을 플레이어/대상 생명력 기준으로 변경하려면 `true`로 설정합니다. (기본값: `false`)
+
+내부 변수 (Lua 편집 필요):
+*   `bupdate_heal`: 받는 치유량/흡수량 표시를 비활성화하려면 `false`로 설정합니다. (기본값: `true`)
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다.

--- a/asHideBagsBar/README.md
+++ b/asHideBagsBar/README.md
@@ -1,0 +1,65 @@
+# asHideBagsBar
+
+asHideBagsBar is a World of Warcraft addon that automatically hides the main Micro Menu (character, spellbook, talents, etc.), the Bags Bar (backpack and other bags), and the Compact Raid Frame Manager (Blizzard's default raid frames toggle). These elements become visible when you move your mouse cursor near their original position.
+
+## Main Features
+
+*   **Auto Show/Hide**:
+    *   Hides the `MicroMenu`, `BagsBar`, and `CompactRaidFrameManager` by default.
+    *   Makes these frames reappear (alpha set to 1) when the mouse cursor is moved within a configurable pixel distance (`AHBB_Offset`) of their boundaries.
+    *   Frames fade back to hidden (alpha set to 0) when the mouse moves away.
+*   **MicroMenu Special Conditions**:
+    *   The `MicroMenu` will also automatically show if the player is in a vehicle or if an override action bar (e.g., vehicle UI, special encounter UI) is active, ensuring access during these states.
+*   **UI Declutter**: Helps to keep the screen cleaner by hiding these elements until they are needed.
+
+## How it Works
+
+1.  Upon loading, the addon sets the alpha of the target frames to 0 (invisible).
+2.  A timer periodically checks the mouse cursor's position.
+3.  If the cursor is detected within the defined offset range of a hidden frame, that frame's alpha is set to 1 (visible).
+4.  When the cursor moves out of the range, the frame's alpha is set back to 0.
+
+## Configuration
+
+Configuration is done by editing Lua variables at the top of `asHideBagsBar/asHideBagsBar.lua`:
+
+*   `AHBB_Offset`: The distance in pixels around the frames that will trigger them to become visible when the mouse hovers within this area.
+    *   Default: `100`
+*   `AHBB_UpdateRate`: How often, in seconds, the addon checks the mouse position to update frame visibility.
+    *   Default: `0.5`
+
+**Note**: This addon does not provide an in-game configuration panel. Changes require editing the `.lua` file.
+
+---
+
+# asHideBagsBar
+
+asHideBagsBar는 월드 오브 워크래프트 애드온으로, 주 마이크로 메뉴(캐릭터, 주문책, 특성 등), 가방 바(배낭 및 기타 가방), 그리고 소규모 공격대 프레임 관리자(블리자드 기본 공격대 프레임 토글)를 자동으로 숨깁니다. 이 요소들은 마우스 커서를 원래 위치 근처로 이동하면 다시 나타납니다.
+
+## 주요 기능
+
+*   **자동 표시/숨기기**:
+    *   기본적으로 `MicroMenu`, `BagsBar`, `CompactRaidFrameManager`를 숨깁니다.
+    *   마우스 커서가 해당 프레임 경계의 설정 가능한 픽셀 거리(`AHBB_Offset`) 내로 이동하면 프레임이 다시 나타나도록(알파값 1로 설정) 합니다.
+    *   마우스가 범위를 벗어나면 프레임은 다시 숨겨집니다(알파값 0으로 설정).
+*   **마이크로 메뉴 특수 조건**:
+    *   플레이어가 차량에 탑승 중이거나 우선 지정 액션 바(예: 차량 UI, 특수 전투 UI)가 활성화된 경우 `MicroMenu`도 자동으로 표시되어 이러한 상태 동안 접근성을 보장합니다.
+*   **UI 정리**: 필요할 때까지 이러한 요소를 숨겨 화면을 더 깔끔하게 유지하는 데 도움을 줍니다.
+
+## 작동 방식
+
+1.  로드 시 애드온은 대상 프레임의 알파값을 0(보이지 않음)으로 설정합니다.
+2.  타이머가 주기적으로 마우스 커서의 위치를 확인합니다.
+3.  숨겨진 프레임의 정의된 오프셋 범위 내에서 커서가 감지되면 해당 프레임의 알파값이 1(보임)로 설정됩니다.
+4.  커서가 범위를 벗어나면 프레임의 알파값이 다시 0으로 설정됩니다.
+
+## 설정
+
+설정은 `asHideBagsBar/asHideBagsBar.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `AHBB_Offset`: 마우스가 이 영역 내에 hovered될 때 프레임이 보이도록 하는 프레임 주변의 픽셀 거리입니다.
+    *   기본값: `100`
+*   `AHBB_UpdateRate`: 애드온이 프레임 표시 여부를 업데이트하기 위해 마우스 위치를 확인하는 빈도(초 단위)입니다.
+    *   기본값: `0.5`
+
+**참고**: 이 애드온은 게임 내 설정 패널을 제공하지 않습니다. 변경하려면 `.lua` 파일을 편집해야 합니다.


### PR DESCRIPTION
…content for several of your addons.

This continues the process of creating README.md files with bilingual descriptions for addons that were previously missing them or only had English placeholders.

The following addons now have complete English and Korean READMEs:
- asDotFilter
- asDotSnapshot
- asFixChat
- asFixClearFont
- asFixCombatText
- asFixHotkey
- asFixUnitFrame
- asGCDBar
- asGearScoreLite
- asHealerChatAlert
- asHideBagsBar

For each of these, I:
1. Examined the addon's Lua file(s) to understand its functionality.
2. Drafted a description of features and configuration in English.
3. Translated the English content to Korean.
4. Structured both into a new README.md file, using asActiveAlert/README.md as a formatting guide.

This work is in response to your feedback requesting complete Korean translations in the README files. I'll be looking at the `asInformation` addon next.