### PR TITLE
I've added README.md files for the remaining addons.

### DIFF
--- a/asInformation/README.md
+++ b/asInformation/README.md
@@ -1,0 +1,83 @@
+# asInformation
+
+asInformation is a World of Warcraft addon that displays a small, movable frame showing your character's key combat statistics: Haste, Critical Strike, Mastery, and Versatility. It includes options to toggle individual stats and set a visual threshold alert for Haste.
+
+## Main Features
+
+*   **Movable Stats Frame**: Provides a draggable frame that can be positioned anywhere on the screen. Its position is saved per character.
+*   **Selectable Stats Display**: Allows you to choose which stats (Haste, Crit, Mastery, Versatility) are visible in the frame.
+*   **Real-time Updates**: Stats are updated periodically to reflect current values.
+*   **Haste Threshold Alert**:
+    *   You can set a custom Haste percentage threshold.
+    *   If your Haste reaches or exceeds this value, the Haste text in the frame will be highlighted (larger font, yellow color) for easy visual confirmation.
+*   **In-Game Options Panel**:
+    *   Accessible via the `/asinformation` slash command.
+    *   Allows you to:
+        *   Lock or unlock the frame's position.
+        *   Toggle the visibility of each stat (Haste, Crit, Mastery, Versatility).
+        *   Adjust the Haste threshold percentage using a slider.
+*   **Localization**: Options panel is localized for Korean and English clients.
+
+## How it Works
+
+1.  The addon creates a main frame and individual text lines for each stat.
+2.  It periodically queries the game API for your character's Haste (`GetHaste()`), Crit (`GetCritChance()`), Mastery (`GetMasteryEffect()`), and Versatility (`GetCombatRatingBonus()` + `GetVersatilityBonus()`).
+3.  The displayed text is updated based on these values and your visibility settings in the options panel.
+4.  If Haste meets the user-defined threshold, its appearance is changed.
+5.  The frame can be dragged if unlocked, and its position is saved. Settings are managed through an options panel.
+
+## Configuration
+
+*   **Accessing Options**: Type `/asinformation` in chat to open the settings panel.
+*   **Options Available**:
+    *   **Lock Frame**: Check to prevent the frame from being moved. Uncheck to allow dragging.
+    *   **Show Haste**: Toggle Haste percentage display.
+    *   **Show Crit**: Toggle Critical Strike percentage display.
+    *   **Show Mastery**: Toggle Mastery percentage display.
+    *   **Show Ver**: Toggle Versatility percentage display.
+    *   **Haste Threshold (Slider)**: Set the Haste value (0-300%) at which the Haste text will be highlighted.
+
+Settings are saved for each character.
+
+---
+
+# asInformation
+
+asInformation은 플레이어 캐릭터의 주요 전투 능력치인 가속, 치명타 및 극대화, 특화, 유연성을 보여주는 작고 이동 가능한 프레임을 표시하는 월드 오브 워크래프트 애드온입니다. 개별 능력치 표시를 토글하고 가속에 대한 시각적 임계값 알림을 설정하는 옵션이 포함되어 있습니다.
+
+## 주요 기능
+
+*   **이동 가능한 능력치 프레임**: 화면 어디에나 위치시킬 수 있는 드래그 가능한 프레임을 제공합니다. 위치는 캐릭터별로 저장됩니다.
+*   **선택적 능력치 표시**: 프레임에 표시할 능력치(가속, 치명타, 특화, 유연성)를 선택할 수 있습니다.
+*   **실시간 업데이트**: 능력치는 현재 값을 반영하여 주기적으로 업데이트됩니다.
+*   **가속 임계값 알림**:
+    *   사용자 지정 가속 백분율 임계값을 설정할 수 있습니다.
+    *   가속이 이 값에 도달하거나 초과하면 프레임의 가속 텍스트가 강조 표시되어(더 큰 글꼴, 노란색) 쉽게 시각적으로 확인할 수 있습니다.
+*   **게임 내 옵션 패널**:
+    *   `/asinformation` 대화창 명령어를 통해 접근할 수 있습니다.
+    *   다음과 같은 작업을 수행할 수 있습니다:
+        *   프레임 위치 잠금 또는 잠금 해제.
+        *   각 능력치(가속, 치명타, 특화, 유연성)의 표시 여부 토글.
+        *   슬라이더를 사용하여 가속 임계값 백분율 조정.
+*   **현지화**: 옵션 패널은 한국어 및 영어 클라이언트에 맞게 현지화되어 있습니다.
+
+## 작동 방식
+
+1.  애드온은 주 프레임과 각 능력치에 대한 개별 텍스트 라인을 생성합니다.
+2.  주기적으로 게임 API를 조회하여 캐릭터의 가속(`GetHaste()`), 치명타(`GetCritChance()`), 특화(`GetMasteryEffect()`) 및 유연성(`GetCombatRatingBonus()` + `GetVersatilityBonus()`) 값을 가져옵니다.
+3.  표시되는 텍스트는 이러한 값과 옵션 패널의 표시 설정에 따라 업데이트됩니다.
+4.  가속이 사용자가 정의한 임계값을 충족하면 모양이 변경됩니다.
+5.  프레임은 잠금 해제된 경우 드래그할 수 있으며 위치가 저장됩니다. 설정은 옵션 패널을 통해 관리됩니다.
+
+## 설정
+
+*   **옵션 접근**: 대화창에 `/asinformation`을 입력하여 설정 패널을 엽니다.
+*   **사용 가능한 옵션**:
+    *   **프레임 잠금**: 프레임 이동을 방지하려면 선택합니다. 드래그를 허용하려면 선택 취소합니다.
+    *   **가속 표시**: 가속 백분율 표시를 토글합니다.
+    *   **크리 표시**: 치명타 및 극대화 백분율 표시를 토글합니다.
+    *   **특화 표시**: 특화 백분율 표시를 토글합니다.
+    *   **유연 표시**: 유연성 백분율 표시를 토글합니다.
+    *   **가속 임계값 (슬라이더)**: 가속 텍스트가 강조 표시될 가속 값(0-300%)을 설정합니다.
+
+설정은 각 캐릭터별로 저장됩니다.

--- a/asInterruptHelper/README.md
+++ b/asInterruptHelper/README.md
@@ -1,0 +1,115 @@
+# asInterruptHelper
+
+asInterruptHelper is a World of Warcraft addon that displays an icon of your best available interrupt or stun spell when your focus, mouseover, or current target begins casting a spell. It integrates with DBM to highlight spells that DBM considers dangerous and prioritizes actions accordingly.
+
+## Main Features
+
+*   **Contextual Interrupt/Stun Display**:
+    *   When an enemy (focus, mouseover, or target) starts casting, the addon shows an icon of one of your interrupt or stun spells.
+    *   **Prioritization**:
+        *   If the enemy cast is uninterruptible, it will prefer to show an available stun.
+        *   If interruptible, it will prefer an available interrupt.
+        *   It considers if your spell will be off cooldown *before* the enemy cast finishes. Spells ready in time are visually emphasized.
+*   **DBM Integration**:
+    *   If DBM (Deadly Boss Mods) is installed, the addon scans DBM's spell information.
+    *   If DBM flags an enemy spell as requiring an "interrupt", `asInterruptHelper` will apply a glow effect to your displayed interrupt/stun icon, signaling higher urgency.
+    *   If an interruptible DBM-flagged dangerous spell is casting and your normal interrupts are on cooldown but a stun is available and would be ready in time, it may suggest the stun.
+*   **Visual Cues**:
+    *   **Icon**: Displays the icon of the suggested player spell.
+    *   **Cooldown**: Shows the cooldown status of your spell. If it will be ready before the enemy cast ends, the cooldown text is larger and red. Otherwise, the icon is desaturated, and text is smaller.
+    *   **Glow Effect**: A pixel glow highlights the icon if the enemy spell is marked as a dangerous interrupt by DBM.
+*   **Dynamic Positioning**:
+    *   **Mouse Follow**: Can be configured to always follow the mouse cursor, or only follow when the casting unit is your mouseover target.
+    *   **Fixed Position**: Alternatively, it can display at a fixed position on the screen.
+*   **Customizable Spell Lists**: The addon includes predefined lists of common interrupt and stun spells with their cooldowns, which advanced users can modify.
+
+## How it Works
+
+1.  **Initialization**: Loads lists of player-known interrupt and stun spells. If DBM is present, it registers to receive DBM's spell data.
+2.  **Target Scanning**: Continuously checks if your focus, mouseover, or current target is casting or channeling a spell.
+3.  **Spell Selection**: If an enemy cast is detected:
+    *   It determines if the cast is interruptible.
+    *   It checks if DBM flags the spell as a dangerous interrupt.
+    *   It then iterates through your available interrupts (and stuns if applicable), prioritizing those that will be off cooldown before the enemy cast finishes.
+4.  **Icon Display**: Shows the icon of the chosen spell, its cooldown status, and applies a glow if the situation is critical (DBM dangerous interrupt).
+5.  **Positioning**: Places the icon either at a fixed spot or near the mouse cursor based on settings and context.
+
+## Configuration
+
+Settings can be accessed via the Blizzard Addon Settings panel:
+1.  Open Game Menu (Esc).
+2.  Click "Options".
+3.  Go to the "AddOns" tab.
+4.  Select "asInterruptHelper".
+5.  Adjust the following:
+    *   **`AlwaysOnMouse` (Checkbox)**:
+        *   `true` (Default): The helper icon will always follow the mouse cursor when an enemy is casting.
+        *   `false`: The icon will only follow the mouse for mouseover target casts; otherwise, it uses a fixed screen position.
+    *   Changing this setting requires a `ReloadUI()`.
+
+Advanced configuration (editing spell lists, icon position, size) requires editing Lua variables at the top of `asInterruptHelper.lua` and within `asInterruptHelperOption.lua`:
+*   `AIH_SIZE`: Size of the displayed icon.
+*   `AIH_X`, `AIH_Y`: Default fixed X and Y position of the icon.
+*   `AIH_M_X`, `AIH_M_Y`: X and Y offset from the mouse cursor when in mouse-follow mode.
+*   `ns.InterruptSpells`, `ns.StunSpells` (in `asInterruptHelperOption.lua`): Tables mapping spell IDs to cooldowns.
+
+The glow effects are provided by `asInterruptHelperLib.lua`.
+
+---
+
+# asInterruptHelper
+
+asInterruptHelper는 주시 대상, 마우스오버 대상 또는 현재 대상이 주문 시전을 시작할 때 사용 가능한 최적의 차단 또는 기절 주문 아이콘을 표시하는 월드 오브 워크래프트 애드온입니다. DBM과 연동하여 DBM이 위험하다고 간주하는 주문을 강조하고 그에 따라 행동의 우선순위를 정합니다.
+
+## 주요 기능
+
+*   **상황별 차단/기절 표시**:
+    *   적(주시, 마우스오버 또는 현재 대상)이 시전을 시작하면 애드온은 플레이어의 차단 또는 기절 주문 중 하나의 아이콘을 보여줍니다.
+    *   **우선순위**:
+        *   적의 시전이 차단 불가능한 경우, 사용 가능한 기절 주문을 우선적으로 표시합니다.
+        *   차단 가능한 경우, 사용 가능한 차단 주문을 우선적으로 표시합니다.
+        *   플레이어의 주문이 적의 시전이 끝나기 *전에* 재사용 대기시간이 완료될지를 고려합니다. 시간 내에 준비되는 주문은 시각적으로 강조됩니다.
+*   **DBM 연동**:
+    *   DBM (Deadly Boss Mods)이 설치된 경우, 애드온은 DBM의 주문 정보를 스캔합니다.
+    *   DBM이 적 주문을 "차단"이 필요하다고 표시하면, `asInterruptHelper`는 표시된 차단/기절 아이콘에 강조 효과를 적용하여 긴급성을 알립니다.
+    *   DBM이 위험하다고 표시한 차단 가능한 주문이 시전 중이고 일반 차단 기술이 재사용 대기 중이지만 기절 기술이 사용 가능하고 시간 내에 준비될 경우, 기절 기술을 제안할 수 있습니다.
+*   **시각적 신호**:
+    *   **아이콘**: 제안된 플레이어 주문의 아이콘을 표시합니다.
+    *   **재사용 대기시간**: 플레이어 주문의 재사용 대기시간 상태를 표시합니다. 적의 시전이 끝나기 전에 준비될 경우, 재사용 대기시간 텍스트가 더 크고 빨간색으로 표시됩니다. 그렇지 않으면 아이콘이 비활성화된 것처럼 보이고 텍스트는 더 작게 표시됩니다.
+    *   **강조 효과**: 적 주문이 DBM에 의해 위험한 차단 기술로 표시된 경우 아이콘에 픽셀 강조 효과가 적용됩니다.
+*   **동적 위치 지정**:
+    *   **마우스 따라다니기**: 적이 시전 중일 때 항상 마우스 커서를 따라다니도록 설정하거나, 시전 중인 유닛이 마우스오버 대상일 때만 따라다니도록 설정할 수 있습니다.
+    *   **고정 위치**: 또는 화면의 고정된 위치에 표시할 수 있습니다.
+*   **사용자 정의 가능한 주문 목록**: 애드온에는 일반적인 차단 및 기절 주문과 해당 재사용 대기시간의 미리 정의된 목록이 포함되어 있으며, 고급 사용자는 이를 수정할 수 있습니다.
+
+## 작동 방식
+
+1.  **초기화**: 플레이어가 알고 있는 차단 및 기절 주문 목록을 로드합니다. DBM이 있는 경우 DBM의 주문 데이터를 수신하도록 등록합니다.
+2.  **대상 스캔**: 주시 대상, 마우스오버 대상 또는 현재 대상이 주문을 시전하거나 채널링 중인지 지속적으로 확인합니다.
+3.  **주문 선택**: 적의 시전이 감지되면:
+    *   시전이 차단 가능한지 확인합니다.
+    *   DBM이 해당 주문을 위험한 차단 기술로 표시했는지 확인합니다.
+    *   그런 다음 사용 가능한 차단 기술(해당되는 경우 기절 기술 포함)을 반복하며, 적의 시전이 끝나기 전에 재사용 대기시간이 완료될 기술을 우선시합니다.
+4.  **아이콘 표시**: 선택한 주문의 아이콘, 재사용 대기시간 상태를 표시하고, 상황이 긴급한 경우(DBM 위험 차단) 강조 효과를 적용합니다.
+5.  **위치 지정**: 설정 및 상황에 따라 아이콘을 고정된 위치 또는 마우스 커서 근처에 배치합니다.
+
+## 설정
+
+설정은 블리자드 애드온 설정 패널을 통해 접근할 수 있습니다:
+1.  게임 메뉴(Esc)를 엽니다.
+2.  "설정"을 클릭합니다.
+3.  "애드온" 탭으로 이동합니다.
+4.  목록에서 "asInterruptHelper"를 선택합니다.
+5.  다음을 조정합니다:
+    *   **`AlwaysOnMouse` (체크박스)**:
+        *   `true` (기본값): 적이 시전 중일 때 도우미 아이콘이 항상 마우스 커서를 따라다닙니다.
+        *   `false`: 아이콘은 마우스오버 대상 시전의 경우에만 마우스를 따라다니며, 그렇지 않으면 고정된 화면 위치를 사용합니다.
+    *   이 설정을 변경하려면 `ReloadUI()`가 필요합니다.
+
+고급 설정(주문 목록, 아이콘 위치, 크기 편집)은 `asInterruptHelper.lua` 파일 상단 및 `asInterruptHelperOption.lua` 내의 Lua 변수를 편집해야 합니다:
+*   `AIH_SIZE`: 표시되는 아이콘의 크기.
+*   `AIH_X`, `AIH_Y`: 아이콘의 기본 고정 X 및 Y 위치.
+*   `AIH_M_X`, `AIH_M_Y`: 마우스 따라다니기 모드일 때 마우스 커서로부터의 X 및 Y 오프셋.
+*   `ns.InterruptSpells`, `ns.StunSpells` (`asInterruptHelperOption.lua` 내): 주문 ID를 재사용 대기시간에 매핑하는 테이블.
+
+강조 효과는 `asInterruptHelperLib.lua`에서 제공됩니다.

--- a/asMisdirection/README.md
+++ b/asMisdirection/README.md
@@ -1,0 +1,93 @@
+# asMisdirection (and Assist/Power Infusion Helper)
+
+asMisdirection is a World of Warcraft addon that automates the creation and management of macros for threat redirection abilities (like Hunter's Misdirection, Rogue's Tricks of the Trade, Evoker's Cauterizing Flame), Priest's Power Infusion, and a general `/assist` macro. It dynamically updates these macros to target the current tank or a manually specified friendly player.
+
+## Main Features
+
+*   **Automatic Macro Creation/Update**:
+    *   **Assist Macro**: Creates a macro named "Assist Tanker" (or "탱커지원" in Korean) that assists the determined tank/target.
+    *   **Threat Redirection Macro**: If you are a Hunter (Misdirection), Rogue (Tricks of the Trade), or Evoker (Cauterizing Flame), it creates a macro named after your respective ability. This macro will cast the spell on the determined tank/target.
+    *   **Power Infusion Macro**: If you are a Priest with Power Infusion, it creates a "Power Infusion" macro to cast it on a determined friendly damage dealer or a manually set target.
+    *   The macros are designed to preserve any additional lines you might have added manually after the main `/cast` command.
+
+*   **Dynamic Targeting**:
+    *   **Automatic Tank Detection**: When in a party or raid, the addon attempts to automatically identify a player with the "TANK" role and sets them as the target for the "Assist" and threat redirection macros. If no tank is found, it defaults to your pet.
+    *   **Automatic Damage Dealer Detection (for Power Infusion)**: For Priests, it attempts to find a "DAMAGER" role in the group (other than yourself) as the default Power Infusion target. If none, it defaults to the player.
+    *   **Manual Override with `/afm`**:
+        *   Target a friendly player in your group and type `/afm`. This player will become the designated target for all managed macros.
+        *   Using `/afm` again on the same manually set target will clear the manual override, reverting to automatic role detection.
+    *   **Priority**: Manually set target > Automatically detected role > Default (pet/player).
+
+*   **Combat Safety**: Macro target updates due to group changes are deferred until you leave combat. The `/afm` command also respects combat lockdown.
+*   **Chat Feedback**: Provides messages in chat when macro targets are set or updated.
+
+## Supported Abilities
+
+*   **General**: `/assist`
+*   **Hunters**: Misdirection
+*   **Rogues**: Tricks of the Trade (macro will be named "Tricks of the Trade")
+*   **Evokers**: Cauterizing Flame (macro will be named "Cauterizing Flame")
+*   **Priests**: Power Infusion
+
+## How to Use
+
+1.  **Automatic Setup**: The addon will automatically detect your class and relevant spells upon login. It will create or update the necessary macros.
+2.  **Macro Usage**: Use the macros created by this addon (e.g., "Assist Tanker", "Misdirection", "Power Infusion") from your macro interface (access via `/m`).
+3.  **Changing Target Manually**:
+    *   To set a specific player as the target for all macros, target them and type `/afm`.
+    *   To clear a manually set target and return to automatic detection, target the currently set player and type `/afm` again.
+    *   The addon will print a confirmation message in chat.
+
+## Notes
+
+*   The addon identifies spells by their specific Spell IDs.
+*   When a macro is updated, it attempts to keep any custom lines you might have added *after* the primary `/cast` line for that spell.
+*   This addon simplifies managing these utility spells, especially in dynamic group content.
+
+---
+
+# asMisdirection (및 지원/마력 주입 도우미)
+
+asMisdirection은 위협 수준 전가 능력(사냥꾼의 눈속임, 도적의 속임수 거래, 기원사의 소작의 불길), 사제의 마력 주입, 그리고 일반적인 `/assist` (지원) 매크로의 생성 및 관리를 자동화하는 월드 오브 워크래프트 애드온입니다. 이 매크로들을 현재의 탱커 또는 수동으로 지정된 아군 플레이어를 대상으로 동적으로 업데이트합니다.
+
+## 주요 기능
+
+*   **자동 매크로 생성/업데이트**:
+    *   **지원 매크로**: 결정된 탱커/대상을 지원하는 "탱커지원" (또는 영문 클라이언트의 경우 "Assist Tanker")이라는 이름의 매크로를 생성합니다.
+    *   **위협 전가 매크로**: 사냥꾼(눈속임), 도적(속임수 거래), 또는 기원사(소작의 불길)인 경우, 각자의 능력 이름을 딴 매크로를 생성합니다. 이 매크로는 결정된 탱커/대상에게 주문을 시전합니다.
+    *   **마력 주입 매크로**: 사제가 마력 주입을 가지고 있는 경우, 결정된 아군 데미지 딜러 또는 수동으로 설정된 대상에게 시전하는 "마력 주입" 매크로를 생성합니다.
+    *   매크로는 주 `/cast` 명령 줄 뒤에 수동으로 추가했을 수 있는 추가 줄을 보존하도록 설계되었습니다.
+
+*   **동적 대상 지정**:
+    *   **자동 탱커 감지**: 파티 또는 공격대에 있을 때, 애드온은 "TANK" 역할을 가진 플레이어를 자동으로 식별하여 "지원" 및 위협 전가 매크로의 대상으로 설정하려고 시도합니다. 탱커를 찾을 수 없는 경우 소환수를 기본값으로 합니다.
+    *   **자동 데미지 딜러 감지 (마력 주입용)**: 사제의 경우, 그룹 내에서 (자신을 제외한) "DAMAGER" 역할을 찾아 마력 주입의 기본 대상으로 삼으려고 시도합니다. 없는 경우 플레이어를 기본값으로 합니다.
+    *   **`/afm`을 사용한 수동 재정의**:
+        *   그룹 내의 아군 플레이어를 대상으로 지정하고 `/afm`을 입력하십시오. 이 플레이어는 관리되는 모든 매크로의 지정 대상이 됩니다.
+        *   현재 수동으로 설정된 대상에게 다시 `/afm`을 사용하면 수동 재정의가 해제되고 자동 역할 감지로 돌아갑니다.
+    *   **우선순위**: 수동 설정 대상 > 자동 감지 역할 > 기본값 (소환수/플레이어).
+
+*   **전투 중 안전성**: 그룹 변경으로 인한 매크로 대상 업데이트는 전투에서 벗어날 때까지 지연됩니다. `/afm` 명령 또한 전투 중 잠금 상태를 존중합니다.
+*   **채팅 피드백**: 매크로 대상이 설정되거나 업데이트될 때 채팅 창에 메시지를 표시합니다.
+
+## 지원되는 능력
+
+*   **일반**: `/assist` (지원)
+*   **사냥꾼**: 눈속임 (Misdirection)
+*   **도적**: 속임수 거래 (Tricks of the Trade) - 매크로 이름은 "속임수 거래"가 됩니다.
+*   **기원사**: 소작의 불길 (Cauterizing Flame) - 매크로 이름은 "소작의 불길"이 됩니다.
+*   **사제**: 마력 주입 (Power Infusion)
+
+## 사용 방법
+
+1.  **자동 설정**: 애드온은 로그인 시 자동으로 직업과 관련 주문을 감지합니다. 필요한 매크로를 생성하거나 업데이트합니다.
+2.  **매크로 사용**: 이 애드온으로 생성된 매크로(예: "탱커지원", "눈속임", "마력 주입")를 매크로 인터페이스(`/m`으로 접근)에서 사용하십시오.
+3.  **수동으로 대상 변경**:
+    *   특정 플레이어를 모든 매크로의 대상으로 설정하려면, 해당 플레이어를 대상으로 지정하고 `/afm`을 입력하십시오.
+    *   수동으로 설정된 대상을 해제하고 자동 감지로 돌아가려면, 현재 설정된 플레이어를 대상으로 지정하고 다시 `/afm`을 입력하십시오.
+    *   애드온은 채팅 창에 확인 메시지를 출력합니다.
+
+## 참고 사항
+
+*   애드온은 특정 주문 ID로 주문을 식별합니다.
+*   매크로가 업데이트될 때, 해당 주문에 대한 기본 `/cast` 줄 *뒤에* 사용자가 추가했을 수 있는 사용자 지정 줄을 유지하려고 시도합니다.
+*   이 애드온은 특히 역동적인 그룹 콘텐츠에서 이러한 유틸리티 주문 관리를 단순화합니다.

--- a/asPremadeGroupsFilter/README.md
+++ b/asPremadeGroupsFilter/README.md
@@ -1,0 +1,111 @@
+# asPremadeGroupsFilter
+
+asPremadeGroupsFilter enhances Blizzard's Premade Groups Finder (LFG List) by providing more detailed visual information about group compositions, primarily for Mythic+ Dungeons and Raid listings.
+
+## Main Features
+
+### For Mythic+ Dungeon Listings (Category ID 2)
+
+*   **Leader's Mythic+ Score Display (`ShowLeaderScore` option)**:
+    *   If enabled (default: true), displays the group leader's overall Mythic+ dungeon score.
+    *   The score is color-coded based on its rating, similar to Blizzard's own color scheme for M+ scores.
+*   **Party Member Specialization Icons & Class Bars**:
+    *   Displays the specialization icon for each member in the group.
+    *   Shows a small colored bar representing the class of each member.
+    *   Optionally shows specialization icons/bars for Tanks (`ShowTankerSpec` option, default: false).
+    *   Optionally shows specialization icons/bars for Healers (`ShowHealerSpec` option, default: false).
+    *   DPS specializations are generally shown if the feature for their role is active.
+    *   A small icon indicates the group leader.
+    *   This information is overlaid on the default role icons in the LFG list, offering a quick glance at group makeup.
+
+### For Raid Listings (Category ID 3)
+
+*   **Role & Class Composition Summary**:
+    *   Displays a count of each class within each role (Tank, Healer, DPS) present in the group.
+    *   Example: `T: W1 P1 H: P2 D1 D: M3 R2 W1` (T=Tank, W=Warrior, P=Paladin, etc.)
+    *   Class counts are colored according to their standard class colors.
+*   **Leader Information**:
+    *   Shows an icon for the leader's role and the first letter of their class, colored by class.
+
+### General
+
+*   **In-Game Configuration**: Options are available in the Blizzard Addon Settings panel.
+*   **Automatic Updates**: Information is updated as you browse the LFG list.
+
+## How it Works
+
+The addon hooks into the standard LFG list update process.
+*   When an entry for a Mythic+ group is displayed, it fetches member details (role, class, spec, leader status) and the leader's M+ score. It then creates and overlays new textures and font strings to show spec icons, class color bars, and the score.
+*   For raid group entries, it counts the number of players for each class within each role and formats this into a summary string, also indicating the leader's class and role.
+*   The visibility of certain details is controlled by user-configurable options.
+
+## Configuration
+
+Settings can be accessed via the Blizzard Addon Settings panel:
+1.  Open Game Menu (Esc).
+2.  Click "Options".
+3.  Go to the "AddOns" tab.
+4.  Select "asPremadeGroupsFilter".
+5.  Adjust the following:
+    *   **`ShowHealerSpec` (Checkbox)**: If checked, specialization icons/bars for Healers will be shown in Mythic+ listings. (Default: false)
+    *   **`ShowTankerSpec` (Checkbox)**: If checked, specialization icons/bars for Tanks will be shown in Mythic+ listings. (Default: false)
+    *   **`ShowLeaderScore` (Checkbox)**: If checked, the group leader's Mythic+ score will be shown in Mythic+ listings. (Default: true)
+
+Changes to these settings are saved per character and typically take effect on the next refresh of the LFG list.
+
+---
+
+# asPremadeGroupsFilter
+
+asPremadeGroupsFilter는 블리자드의 미리 구성된 그룹 찾기(LFG 목록)를 강화하여, 주로 신화 쐐기돌 던전 및 공격대 목록에 대한 그룹 구성에 대한 더 자세한 시각적 정보를 제공합니다.
+
+## 주요 기능
+
+### 신화 쐐기돌 던전 목록용 (카테고리 ID 2)
+
+*   **파티장의 신화 쐐기돌 점수 표시 (`ShowLeaderScore` 옵션)**:
+    *   활성화된 경우(기본값: true), 그룹 리더의 전체 신화 쐐기돌 던전 점수를 표시합니다.
+    *   점수는 M+ 점수에 대한 블리자드 자체 색상 구성표와 유사하게 등급에 따라 색상으로 구분됩니다.
+*   **파티원 전문화 아이콘 및 직업 바**:
+    *   그룹의 각 구성원에 대한 전문화 아이콘을 표시합니다.
+    *   각 구성원의 직업을 나타내는 작은 색상 바를 표시합니다.
+    *   선택적으로 탱커에 대한 전문화 아이콘/바를 표시합니다 (`ShowTankerSpec` 옵션, 기본값: false).
+    *   선택적으로 힐러에 대한 전문화 아이콘/바를 표시합니다 (`ShowHealerSpec` 옵션, 기본값: false).
+    *   딜러 전문화는 해당 역할에 대한 기능이 활성화된 경우 일반적으로 표시됩니다.
+    *   작은 아이콘이 그룹 리더를 나타냅니다.
+    *   이 정보는 LFG 목록의 기본 역할 아이콘 위에 오버레이되어 그룹 구성을 빠르게 파악할 수 있도록 합니다.
+
+### 공격대 목록용 (카테고리 ID 3)
+
+*   **역할 및 직업 구성 요약**:
+    *   그룹에 있는 각 역할(탱커, 힐러, 딜러) 내 각 직업의 수를 표시합니다.
+    *   예: `T: W1 P1 H: P2 D1 D: M3 R2 W1` (T=탱커, W=전사, P=성기사 등)
+    *   직업 수는 표준 직업 색상에 따라 색상이 지정됩니다.
+*   **파티장 정보**:
+    *   파티장의 역할 아이콘과 직업의 첫 글자를 직업 색상으로 표시합니다.
+
+### 일반
+
+*   **게임 내 설정**: 블리자드 애드온 설정 패널에서 옵션을 사용할 수 있습니다.
+*   **자동 업데이트**: LFG 목록을 탐색할 때 정보가 업데이트됩니다.
+
+## 작동 방식
+
+애드온은 표준 LFG 목록 업데이트 프로세스에 연결됩니다.
+*   신화 쐐기돌 그룹 항목이 표시되면 구성원 세부 정보(역할, 직업, 전문화, 파티장 상태)와 파티장의 M+ 점수를 가져옵니다. 그런 다음 새로운 텍스처와 글꼴 문자열을 만들고 오버레이하여 전문화 아이콘, 직업 색상 바 및 점수를 표시합니다.
+*   공격대 그룹 항목의 경우 각 역할 내 각 직업의 플레이어 수를 계산하고 이를 요약 문자열로 형식화하며 파티장의 직업과 역할도 표시합니다.
+*   특정 세부 정보의 표시는 사용자가 구성할 수 있는 옵션에 의해 제어됩니다.
+
+## 설정
+
+설정은 블리자드 애드온 설정 패널을 통해 접근할 수 있습니다:
+1.  게임 메뉴(Esc)를 엽니다.
+2.  "설정"을 클릭합니다.
+3.  "애드온" 탭으로 이동합니다.
+4.  목록에서 "asPremadeGroupsFilter"를 선택합니다.
+5.  다음을 조정합니다:
+    *   **`ShowHealerSpec` (체크박스)**: 선택하면 신화 쐐기돌 목록에 힐러의 전문화 아이콘/바가 표시됩니다. (기본값: false)
+    *   **`ShowTankerSpec` (체크박스)**: 선택하면 신화 쐐기돌 목록에 탱커의 전문화 아이콘/바가 표시됩니다. (기본값: false)
+    *   **`ShowLeaderScore` (체크박스)**: 선택하면 신화 쐐기돌 목록에 그룹 리더의 신화 쐐기돌 점수가 표시됩니다. (기본값: true)
+
+이러한 설정 변경 사항은 캐릭터별로 저장되며 일반적으로 LFG 목록을 다음에 새로고침할 때 적용됩니다.

--- a/asRangeDisplay/README.md
+++ b/asRangeDisplay/README.md
@@ -1,0 +1,89 @@
+# asRangeDisplay
+
+asRangeDisplay is a World of Warcraft addon that shows the approximate range to your current target as a text display on your screen. It uses different methods for range calculation depending on whether you are in combat or targeting a friendly/hostile unit.
+
+## Main Features
+
+*   **Dynamic Range Text**: Displays a numerical value representing your estimated range to the current target.
+*   **Contextual Range Calculation**:
+    *   **Out of Combat / Friendly Targets**: Uses a predefined list of items with known ranges. It checks which item is the shortest-range one currently usable on the target to estimate range.
+    *   **In Combat (Hostile Targets)**: Scans your spellbook for spells with a maximum range. It then checks which of these spells are currently in range of your target and displays the shortest maximum range among them. This effectively shows your current shortest combat engagement range.
+*   **Color-Coded Display**: The range text changes color based on the distance:
+    *   Red: > 40 yards
+    *   Yellow/Orange: > 30-40 yards
+    *   Green: > 20-30 yards
+    *   Cyan/Blueish: > 5-20 yards
+    *   Grey/White: <= 5 yards or when range is 0.
+*   **Customizable Position**:
+    *   Can be positioned using X/Y offsets.
+    *   Option to link its position relative to `asHealthText` addon's raid icon display.
+    *   If `asMOD` is installed, its position can be managed by `asMOD`.
+*   **Configurable Update Rate**: The frequency of range checks can be adjusted.
+
+## How it Works
+
+1.  **Initialization**: The addon loads predefined lists of items (for out-of-combat checks) and scans the player's spellbook (for in-combat checks) to cache spell ranges.
+2.  **Target Change/Periodic Update**: When the target changes or on a regular timer:
+    *   It determines if the target is friendly or hostile and if the player is in combat.
+    *   **Out-of-Combat/Friendly**: It iterates through a list of items (e.g., bandages, nets, quest items with ranges) and uses `IsItemInRange()` to find the item with the shortest range that can currently be used on the target. This item's known range is displayed.
+    *   **In-Combat (Hostile)**: It iterates through the player's known spells, checks which ones are in range using `C_Spell.IsSpellInRange()`, and then displays the shortest maximum range among those currently usable spells.
+3.  The displayed range number is then colored according to the distance.
+
+## Configuration
+
+Configuration is done by editing Lua variables at the top of `asRangeDisplay/asRangeDisplay.lua`:
+
+*   `ARD_Font`: Font face for the range text. (Default: `STANDARD_TEXT_FONT`)
+*   `ARD_FontSize`: Font size. (Default: 16)
+*   `ARD_FontOutline`: Font outline style (e.g., "THICKOUTLINE"). (Default: "THICKOUTLINE")
+*   `ARD_X`, `ARD_Y`: Default X and Y offsets from the screen center if not linked to `asHealthText` or managed by `asMOD`. (Defaults: 0, -130)
+*   `ARD_AHT`: Set to `true` to attempt to position the range display next to `asHealthText`'s raid icon. (Default: `false`)
+*   `ARD_UpdateRate`: How often (in seconds) the range is checked and updated. (Default: 0.25)
+
+**Note**: This addon does not provide a dedicated in-game configuration panel for these settings unless its position is managed by `asMOD`.
+
+---
+
+# asRangeDisplay
+
+asRangeDisplay는 현재 대상까지의 대략적인 거리를 화면에 텍스트로 표시하는 월드 오브 워크래프트 애드온입니다. 전투 중인지 또는 우호적/적대적 대상을 선택했는지에 따라 다른 방법으로 거리를 계산합니다.
+
+## 주요 기능
+
+*   **동적 거리 텍스트**: 현재 대상까지의 예상 거리를 나타내는 숫자 값을 표시합니다.
+*   **상황별 거리 계산**:
+    *   **비전투 중 / 우호적 대상**: 알려진 사정거리를 가진 미리 정의된 아이템 목록을 사용합니다. 현재 대상에게 사용할 수 있는 가장 짧은 사정거리의 아이템을 확인하여 거리를 추정합니다.
+    *   **전투 중 (적대적 대상)**: 사용자의 주문책을 스캔하여 최대 사정거리를 가진 주문을 찾습니다. 그런 다음 이 주문들 중 현재 대상에게 사정거리가 닿는 주문을 확인하고 그중 가장 짧은 최대 사정거리를 표시합니다. 이는 사실상 현재 가장 짧은 교전 가능 거리를 보여줍니다.
+*   **색상 구분 표시**: 거리 텍스트는 거리에 따라 색상이 변경됩니다:
+    *   빨간색: > 40미터
+    *   노란색/주황색: > 30-40미터
+    *   녹색: > 20-30미터
+    *   청록색/파란색 계열: > 5-20미터
+    *   회색/흰색: <= 5미터 또는 거리 0.
+*   **사용자 정의 가능한 위치**:
+    *   X/Y 오프셋을 사용하여 위치를 지정할 수 있습니다.
+    *   `asHealthText` 애드온의 공격대 아이콘 표시에 상대적으로 위치를 연결하는 옵션이 있습니다.
+    *   `asMOD`가 설치된 경우, 해당 위치는 `asMOD`에 의해 관리될 수 있습니다.
+*   **설정 가능한 업데이트 속도**: 거리 확인 빈도를 조정할 수 있습니다.
+
+## 작동 방식
+
+1.  **초기화**: 애드온은 미리 정의된 아이템 목록(비전투 확인용)을 로드하고 플레이어의 주문책을 스캔하여(전투 중 확인용) 주문 사정거리를 캐시합니다.
+2.  **대상 변경/주기적 업데이트**: 대상이 변경되거나 정기적인 타이머에 따라:
+    *   대상이 우호적인지 적대적인지, 플레이어가 전투 중인지 확인합니다.
+    *   **비전투/우호적 대상**: 아이템 목록(예: 붕대, 그물, 사정거리가 있는 퀘스트 아이템)을 반복하고 `IsItemInRange()`를 사용하여 현재 대상에게 사용할 수 있는 가장 짧은 사정거리의 아이템을 찾습니다. 이 아이템의 알려진 사정거리가 표시됩니다.
+    *   **전투 중 (적대적 대상)**: 플레이어가 알고 있는 주문을 반복하고 `C_Spell.IsSpellInRange()`를 사용하여 사정거리 내에 있는 주문을 확인한 다음, 현재 사용할 수 있는 주문 중 가장 짧은 최대 사정거리를 표시합니다.
+3.  표시된 거리 숫자는 거리에 따라 색상이 지정됩니다.
+
+## 설정
+
+설정은 `asRangeDisplay/asRangeDisplay.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `ARD_Font`: 거리 텍스트의 글꼴입니다. (기본값: `STANDARD_TEXT_FONT`)
+*   `ARD_FontSize`: 글꼴 크기입니다. (기본값: 16)
+*   `ARD_FontOutline`: 글꼴 외곽선 스타일입니다 (예: "THICKOUTLINE"). (기본값: "THICKOUTLINE")
+*   `ARD_X`, `ARD_Y`: `asHealthText`에 연결되거나 `asMOD`에 의해 관리되지 않는 경우 화면 중앙으로부터의 기본 X 및 Y 오프셋입니다. (기본값: 0, -130)
+*   `ARD_AHT`: `asHealthText`의 공격대 아이콘 옆에 거리 표시를 위치시키려면 `true`로 설정합니다. (기본값: `false`)
+*   `ARD_UpdateRate`: 거리를 확인하고 업데이트하는 빈도(초 단위)입니다. (기본값: 0.25)
+
+**참고**: 이 애드온은 해당 위치가 `asMOD`에 의해 관리되지 않는 한 이러한 설정을 위한 전용 게임 내 설정 패널을 제공하지 않습니다.

--- a/asReady/README.md
+++ b/asReady/README.md
@@ -1,0 +1,129 @@
+# asReady
+
+asReady is a World of Warcraft addon designed to track and display important cooldowns for your party and raid members. It focuses on two main categories: party interrupts and major offensive cooldowns.
+
+## Main Features
+
+### 1. Party Interrupt Cooldown Display (`ShowPartyInterrupt` option)
+
+*   When in a 5-man party (not a raid), this feature displays a list of recently used interrupt spells by party members.
+*   Each entry shows:
+    *   The icon of the interrupt spell used.
+    *   The name of the party member who used it (colored by class).
+    *   The remaining cooldown on their interrupt.
+    *   The text "ON" in green if the interrupt is ready.
+*   This display is a separate, movable frame (can be managed by `asMOD` if installed).
+*   Helps coordinate interrupts in small group content.
+*   The list of tracked interrupt spells is defined in `asReadyOption.lua`.
+
+### 2. Offensive Cooldown Display on Unit Frames (`ShowPartyCool` & `ShowRaidCool` options)
+
+*   Tracks major offensive cooldowns for all party and raid members based on their class and specialization.
+*   Displays a small icon with cooldown text directly overlaid on each player's unit frame (in the Blizzard Compact Party/Raid Frames).
+*   **Visual Cues**:
+    *   Shows the icon of the specific offensive cooldown (e.g., Combustion, Avenging Wrath).
+    *   Displays the remaining cooldown as a number.
+    *   If the buff associated with the cooldown is currently active on the player, the icon is shown normally saturated.
+    *   If the spell is on cooldown but the buff is not active, the icon is desaturated.
+    *   The cooldown text turns red when the remaining time is very short (e.g., < 4 seconds).
+*   Uses `LibOpenRaid-1.0` (an embedded library) to gather cooldown information for raid members other than the player.
+*   The specific offensive cooldowns tracked for each class/spec are defined in `asReadyOption.lua`.
+*   Helps visualize the availability of key damage cooldowns across the group.
+
+### General
+
+*   **In-Game Configuration**: Options to toggle these features are available in the Blizzard Addon Settings panel.
+*   **`asMOD` Integration**: The party interrupt display frame can be positioned using `asMOD` if it's installed.
+
+## How it Works
+
+1.  **Spell Definition**: The addon uses predefined lists in `asReadyOption.lua` to know which interrupt spells and major offensive cooldowns to track for each class and specialization.
+2.  **Event Monitoring**: It listens for `UNIT_SPELLCAST_SUCCEEDED` events to detect when tracked spells are used by group members.
+3.  **Cooldown Tracking**:
+    *   For party interrupts, it updates a dedicated list display.
+    *   For offensive cooldowns, it uses `C_Spell.GetSpellCooldown` for the player and `LibOpenRaid` for other group members to get current cooldown status.
+4.  **Display Update**:
+    *   Party interrupt bars are updated with remaining times.
+    *   Offensive cooldown icons are dynamically updated on the compact unit frames.
+    *   The addon also updates its state on group changes, spec changes, and logins.
+
+## Configuration
+
+Settings can be accessed via the Blizzard Addon Settings panel:
+1.  Open Game Menu (Esc).
+2.  Click "Options".
+3.  Go to the "AddOns" tab.
+4.  Select "asReady".
+5.  Adjust the following:
+    *   **`ShowPartyInterrupt` (Checkbox)**: Toggle the display of the party interrupt cooldown bars. (Default: true)
+    *   **`ShowPartyCool` (Checkbox)**: Toggle the display of offensive cooldowns on party unit frames. (Default: true)
+    *   **`ShowRaidCool` (Checkbox)**: Toggle the display of offensive cooldowns on raid unit frames. (Default: true)
+    *   Changing these settings requires a `ReloadUI()`.
+
+Advanced configuration (editing spell lists, default position of interrupt bars) requires editing Lua variables in `asReady.lua` and `asReadyOption.lua`.
+
+---
+
+# asReady
+
+asReady는 파티 및 공격대원의 중요 재사용 대기시간을 추적하고 표시하도록 설계된 월드 오브 워크래프트 애드온입니다. 주로 파티 차단 기술과 주요 공격 관련 재사용 대기시간의 두 가지 주요 범주에 중점을 둡니다.
+
+## 주요 기능
+
+### 1. 파티 차단 기술 재사용 대기시간 표시 (`ShowPartyInterrupt` 옵션)
+
+*   공격대가 아닌 5인 파티에 있을 때, 이 기능은 파티원들이 최근 사용한 차단 주문 목록을 표시합니다.
+*   각 항목은 다음을 보여줍니다:
+    *   사용된 차단 주문의 아이콘.
+    *   사용한 파티원의 이름 (직업 색상으로 표시).
+    *   해당 차단 기술의 남은 재사용 대기시간.
+    *   차단 기술이 준비되면 녹색으로 "ON" 텍스트 표시.
+*   이 표시는 별도의 이동 가능한 프레임입니다 (`asMOD`가 설치된 경우 관리 가능).
+*   소규모 그룹 콘텐츠에서 차단 기술을 조율하는 데 도움을 줍니다.
+*   추적되는 차단 주문 목록은 `asReadyOption.lua`에 정의되어 있습니다.
+
+### 2. 유닛 프레임에 공격 관련 재사용 대기시간 표시 (`ShowPartyCool` & `ShowRaidCool` 옵션)
+
+*   모든 파티 및 공격대원의 주요 공격 관련 재사용 대기시간을 해당 직업 및 전문화에 따라 추적합니다.
+*   각 플레이어의 유닛 프레임(블리자드 소규모 파티/공격대 프레임)에 직접 오버레이된 작은 아이콘과 재사용 대기시간 텍스트를 표시합니다.
+*   **시각적 신호**:
+    *   특정 공격 관련 재사용 대기시간의 아이콘을 표시합니다 (예: 발화, 응징의 격노).
+    *   남은 재사용 대기시간을 숫자로 표시합니다.
+    *   재사용 대기시간과 관련된 강화 효과가 현재 플레이어에게 활성화되어 있으면 아이콘이 정상 채도로 표시됩니다.
+    *   주문이 재사용 대기 중이지만 강화 효과가 활성화되지 않은 경우 아이콘이 비활성화된 것처럼 약간 어둡게 표시됩니다.
+    *   남은 시간이 매우 짧을 때(예: 4초 미만) 재사용 대기시간 텍스트가 빨간색으로 바뀝니다.
+*   플레이어 이외의 공격대원 재사용 대기시간 정보를 수집하기 위해 `LibOpenRaid-1.0`(내장 라이브러리)을 사용합니다.
+*   각 직업/전문화별로 추적되는 특정 공격 관련 재사용 대기시간은 `asReadyOption.lua`에 정의되어 있습니다.
+*   그룹 전체의 주요 공격 관련 재사용 대기시간 가용성을 시각화하는 데 도움을 줍니다.
+
+### 일반
+
+*   **게임 내 설정**: 이러한 기능을 토글하는 옵션은 블리자드 애드온 설정 패널에서 사용할 수 있습니다.
+*   **`asMOD` 연동**: 파티 차단 표시 프레임은 `asMOD`가 설치된 경우 이를 사용하여 위치를 지정할 수 있습니다.
+
+## 작동 방식
+
+1.  **주문 정의**: 애드온은 `asReadyOption.lua`의 미리 정의된 목록을 사용하여 각 직업 및 전문화에 대해 추적할 차단 주문과 주요 공격 관련 재사용 대기시간을 인식합니다.
+2.  **이벤트 감시**: `UNIT_SPELLCAST_SUCCEEDED` 이벤트를 수신하여 그룹 구성원이 추적된 주문을 사용할 때를 감지합니다.
+3.  **재사용 대기시간 추적**:
+    *   파티 차단의 경우 전용 목록 표시를 업데이트합니다.
+    *   공격 관련 재사용 대기시간의 경우 플레이어에게는 `C_Spell.GetSpellCooldown`을 사용하고 다른 그룹 구성원에게는 `LibOpenRaid`를 사용하여 현재 재사용 대기시간 상태를 가져옵니다.
+4.  **표시 업데이트**:
+    *   파티 차단 바가 남은 시간으로 업데이트됩니다.
+    *   공격 관련 재사용 대기시간 아이콘이 소규모 유닛 프레임에서 동적으로 업데이트됩니다.
+    *   애드온은 또한 그룹 변경, 전문화 변경 및 로그인 시 상태를 업데이트합니다.
+
+## 설정
+
+설정은 블리자드 애드온 설정 패널을 통해 접근할 수 있습니다:
+1.  게임 메뉴(Esc)를 엽니다.
+2.  "설정"을 클릭합니다.
+3.  "애드온" 탭으로 이동합니다.
+4.  목록에서 "asReady"를 선택합니다.
+5.  다음을 조정합니다:
+    *   **`ShowPartyInterrupt` (체크박스)**: 파티 차단 기술 재사용 대기시간 바 표시를 토글합니다. (기본값: true)
+    *   **`ShowPartyCool` (체크박스)**: 파티 유닛 프레임에 공격 관련 재사용 대기시간 표시를 토글합니다. (기본값: true)
+    *   **`ShowRaidCool` (체크박스)**: 공격대 유닛 프레임에 공격 관련 재사용 대기시간 표시를 토글합니다. (기본값: true)
+    *   이러한 설정을 변경하려면 `ReloadUI()`가 필요합니다.
+
+고급 설정(주문 목록 편집, 차단 바의 기본 위치)은 `asReady.lua` 및 `asReadyOption.lua`의 Lua 변수를 편집해야 합니다.

--- a/asScavenger/README.md
+++ b/asScavenger/README.md
@@ -1,0 +1,47 @@
+# asScavenger
+
+asScavenger is a lightweight World of Warcraft addon that automatically sells all "Poor" quality (grey) items from your bags to a vendor when you open a merchant window.
+
+## Main Features
+
+*   **Automatic Junk Selling**: When you interact with any vendor, the addon scans your backpack and main bag slots.
+*   **Sells Grey Items**: Any item with "Poor" (grey) quality is automatically sold to the currently open merchant.
+*   **Efficiency**: Helps keep your bags clean from junk items and quickly converts them to copper/silver/gold without manual clicking.
+
+## How it Works
+
+1.  The addon listens for the `MERCHANT_SHOW` event, which occurs when you open a window to interact with a vendor.
+2.  Upon this event, it iterates through all slots in your main bags (backpack and the four additional bags).
+3.  For each item found, it checks its quality using `GetItemInfo`.
+4.  If the item's quality is 0 (Poor/grey), it calls `C_Container.UseContainerItem(bag, slot)`. When a merchant window is open, this action sells the item to the vendor.
+
+## Configuration
+
+This addon has no configurable options. It works automatically when enabled.
+
+**Note**: Be mindful if you have any grey items you wish to keep for any specific reason, as this addon will attempt to sell them automatically when you visit a vendor.
+
+---
+
+# asScavenger
+
+asScavenger는 월드 오브 워크래프트 애드온으로, 상인 창을 열 때 가방에 있는 모든 "일반" 등급(회색) 아이템을 자동으로 상인에게 판매합니다.
+
+## 주요 기능
+
+*   **자동 잡템 판매**: 상인과 상호작용할 때, 애드온이 배낭 및 주 가방 슬롯을 스캔합니다.
+*   **회색 아이템 판매**: "일반"(회색) 등급의 모든 아이템이 현재 열려 있는 상인에게 자동으로 판매됩니다.
+*   **효율성**: 수동 클릭 없이 잡템으로부터 가방을 깨끗하게 유지하고 빠르게 구리/은/금으로 전환하는 데 도움을 줍니다.
+
+## 작동 방식
+
+1.  애드온은 상인과 상호작용하는 창을 열 때 발생하는 `MERCHANT_SHOW` 이벤트를 수신합니다.
+2.  이 이벤트가 발생하면 주 가방(배낭 및 추가 가방 4개)의 모든 슬롯을 반복합니다.
+3.  발견된 각 아이템에 대해 `GetItemInfo`를 사용하여 품질을 확인합니다.
+4.  아이템의 품질이 0(일반/회색)이면 `C_Container.UseContainerItem(bag, slot)`을 호출합니다. 상인 창이 열려 있을 때 이 작업은 아이템을 상인에게 판매합니다.
+
+## 설정
+
+이 애드온에는 설정 가능한 옵션이 없습니다. 활성화되면 자동으로 작동합니다.
+
+**참고**: 특별한 이유로 보관하고 싶은 회색 아이템이 있는 경우, 이 애드온은 상인을 방문할 때 해당 아이템을 자동으로 판매하려고 시도하므로 주의하십시오.

--- a/asSpamFilter/README.md
+++ b/asSpamFilter/README.md
@@ -1,0 +1,83 @@
+# asSpamFilter
+
+asSpamFilter is a World of Warcraft addon designed to reduce the visual clutter from repetitive UI error messages. It achieves this by completely hiding certain common errors and "throttling" others, preventing the same message from spamming your screen multiple times in quick succession.
+
+## Main Features
+
+*   **Custom Error Frame**: Replaces the default Blizzard UI error frame with its own, allowing it to intercept and filter messages.
+*   **Message Blacklisting**:
+    *   Completely suppresses a predefined list of common spammy errors, such as:
+        *   "Ability is not ready yet" (`LE_GAME_ERR_ABILITY_COOLDOWN`)
+        *   "Spell is not ready yet" (`LE_GAME_ERR_SPELL_COOLDOWN`)
+        *   "Not enough mana/energy/rage/etc." (various `LE_GAME_ERR_OUT_OF_*` types)
+        *   "Out of range" (`LE_GAME_ERR_OUT_OF_RANGE`) - *Note: This is in the blacklist, meaning it's hidden entirely, not just throttled by default.*
+*   **Message Throttling**:
+    *   For another list of common errors (e.g., "Item is not ready yet", "Another action is in progress", "You are in shapeshift form"), if the exact same error message for the same error type occurs again while it's still visible:
+        *   The new, duplicate message is not displayed.
+        *   Instead, the existing message on screen will "flash" (briefly change color) to indicate a repeat occurrence, if the CVar `flashErrorMessageRepeats` is enabled in WoW's interface options.
+        *   The fade-out timer for the existing message is reset.
+*   **Customizable Position**: The position of the error message frame can be adjusted. If the `asMOD` addon is installed, it can be managed through `asMOD`'s frame positioning system.
+
+## How it Works
+
+1.  The addon defines its own UI message frame (`asUIErrorsFrame`).
+2.  It intercepts all UI error messages before they reach the default error frame.
+3.  It checks the `messageType` of each error against two internal lists:
+    *   **`BLACK_LISTED_MESSAGE_TYPES`**: If the error type is in this list, the message is completely ignored.
+    *   **`THROTTLED_MESSAGE_TYPES`**: If the error type is in this list, the addon checks if the exact same message string for that type is already displayed.
+        *   If yes, the new message is suppressed, and the existing one flashes/re-fades.
+        *   If no (it's a new message string or a new type of throttled error), it's allowed to display.
+4.  Allowed messages are shown in the `asUIErrorsFrame`.
+
+## Configuration
+
+*   **Frame Position**:
+    *   Default X and Y offsets for the error frame can be set by editing `ASF_X` and `ASF_Y` at the top of `asSpamFilter/asSpamFilter.lua`.
+    *   If `asMOD` is installed, the frame "asSpamFilter" can be moved and its position saved using `asMOD`'s interface.
+*   **Flash Behavior**: The "flash" effect for throttled messages depends on the Blizzard CVar `flashErrorMessageRepeats`. This can be toggled in the standard WoW Interface Options (usually under Display or Combat).
+*   **Filtered Messages**: Advanced users can modify the `BLACK_LISTED_MESSAGE_TYPES` and `THROTTLED_MESSAGE_TYPES` tables in `asSpamFilter.lua` to customize which messages are hidden or throttled.
+
+**Note**: The variable `ASF_MaxTime` is defined in the Lua file but is not currently used by the addon's logic. The throttling is based on identical message content, not a time window.
+
+---
+
+# asSpamFilter
+
+asSpamFilter는 반복적인 UI 오류 메시지로 인한 화면 혼잡을 줄이기 위해 설계된 월드 오브 워크래프트 애드온입니다. 특정 일반적인 오류를 완전히 숨기거나 다른 오류들을 "조절"하여 동일한 메시지가 짧은 시간 내에 여러 번 화면에 도배되는 것을 방지합니다.
+
+## 주요 기능
+
+*   **사용자 지정 오류 프레임**: 기본 블리자드 UI 오류 프레임을 자체 프레임으로 대체하여 메시지를 가로채고 필터링할 수 있도록 합니다.
+*   **메시지 블랙리스트**:
+    *   다음과 같이 미리 정의된 일반적인 스팸성 오류 목록을 완전히 억제합니다:
+        *   "능력을 아직 사용할 수 없습니다" (`LE_GAME_ERR_ABILITY_COOLDOWN`)
+        *   "주문을 아직 사용할 수 없습니다" (`LE_GAME_ERR_SPELL_COOLDOWN`)
+        *   "마나/기력/분노 등이 부족합니다" (다양한 `LE_GAME_ERR_OUT_OF_*` 유형)
+        *   "사정거리를 벗어났습니다" (`LE_GAME_ERR_OUT_OF_RANGE`) - *참고: 이 항목은 블랙리스트에 있어 기본적으로 조절되는 것이 아니라 완전히 숨겨집니다.*
+*   **메시지 조절**:
+    *   다른 일반적인 오류 목록(예: "아이템을 아직 사용할 수 없습니다", "다른 작업이 진행 중입니다", "변신 상태입니다")의 경우, 동일한 오류 유형에 대해 정확히 동일한 오류 메시지가 아직 화면에 표시되는 동안 다시 발생하면:
+        *   새로운 중복 메시지는 표시되지 않습니다.
+        *   대신, 화면의 기존 메시지가 WoW 인터페이스 옵션에서 `flashErrorMessageRepeats` CVar가 활성화된 경우 반복 발생을 나타내기 위해 "깜빡입니다"(잠시 색상 변경).
+        *   기존 메시지의 사라짐 타이머가 재설정됩니다.
+*   **사용자 정의 가능한 위치**: 오류 메시지 프레임의 위치를 조정할 수 있습니다. `asMOD` 애드온이 설치된 경우, `asMOD`의 프레임 위치 지정 시스템을 통해 관리할 수 있습니다.
+
+## 작동 방식
+
+1.  애드온은 자체 UI 메시지 프레임(`asUIErrorsFrame`)을 정의합니다.
+2.  모든 UI 오류 메시지가 기본 오류 프레임에 도달하기 전에 가로챕니다.
+3.  각 오류의 `messageType`을 두 개의 내부 목록과 대조하여 확인합니다:
+    *   **`BLACK_LISTED_MESSAGE_TYPES`**: 오류 유형이 이 목록에 있으면 메시지가 완전히 무시됩니다.
+    *   **`THROTTLED_MESSAGE_TYPES`**: 오류 유형이 이 목록에 있으면 애드온은 해당 유형에 대해 정확히 동일한 메시지 문자열이 이미 표시되어 있는지 확인합니다.
+        *   그렇다면 새 메시지는 억제되고 기존 메시지는 깜빡이거나 다시 사라지기 시작합니다.
+        *   그렇지 않다면 (새로운 메시지 문자열이거나 새로운 유형의 조절된 오류인 경우) 표시되도록 허용됩니다.
+4.  허용된 메시지는 `asUIErrorsFrame`에 표시됩니다.
+
+## 설정
+
+*   **프레임 위치**:
+    *   오류 프레임의 기본 X 및 Y 오프셋은 `asSpamFilter/asSpamFilter.lua` 파일 상단의 `ASF_X` 및 `ASF_Y`를 편집하여 설정할 수 있습니다.
+    *   `asMOD`가 설치된 경우, "asSpamFilter" 프레임은 `asMOD`의 인터페이스를 사용하여 이동하고 위치를 저장할 수 있습니다.
+*   **깜빡임 동작**: 조절된 메시지에 대한 "깜빡임" 효과는 블리자드 CVar `flashErrorMessageRepeats`에 따라 달라집니다. 이는 표준 WoW 인터페이스 옵션(일반적으로 표시 또는 전투 항목 아래)에서 토글할 수 있습니다.
+*   **필터링된 메시지**: 고급 사용자는 `asSpamFilter.lua`의 `BLACK_LISTED_MESSAGE_TYPES` 및 `THROTTLED_MESSAGE_TYPES` 테이블을 수정하여 어떤 메시지를 숨기거나 조절할지 사용자 정의할 수 있습니다.
+
+**참고**: `ASF_MaxTime` 변수는 Lua 파일에 정의되어 있지만 현재 애드온의 로직에서는 사용되지 않습니다. 조절은 시간 창이 아닌 동일한 메시지 내용을 기반으로 합니다.

--- a/asTargetCastBar/README.md
+++ b/asTargetCastBar/README.md
@@ -1,0 +1,113 @@
+# asTargetCastBar
+
+asTargetCastBar is a World of Warcraft addon that displays a dedicated, movable cast bar for your current target. It provides visual cues for spell interruptibility, whether the spell is targeting you, and integrates with DBM to highlight dangerous spells.
+
+## Main Features
+
+*   **Dedicated Target Cast Bar**: Shows a clear cast bar for any spell or channel being cast by your current target.
+*   **Visual Information**:
+    *   **Spell Icon**: Displays the icon of the spell being cast.
+    *   **Spell Name**: Shows the name of the spell.
+    *   **Cast Time**: Displays numerical `current / total` cast time.
+    *   **Target's Target**: If your target is casting at another player, that player's name is shown below the cast bar, colored by their class.
+*   **Color-Coded Interrupt Status**:
+    *   The cast bar changes color based on:
+        *   Whether the spell is interruptible or not.
+        *   Whether the spell is being cast on you (the player).
+    *   Default colors help quickly identify threat and interrupt opportunities:
+        *   Dark Pink/Purple: Uninterruptible, targeting you.
+        *   Grey: Uninterruptible, not targeting you.
+        *   Green: Interruptible, targeting you.
+        *   Light Green/Yellow: Interruptible, not targeting you.
+*   **DBM Integration for Dangerous Spells**:
+    *   If DBM (Deadly Boss Mods) is installed, the addon scans DBM's data.
+    *   If your target is casting a spell that DBM flags as a dangerous "interrupt" type, a pixel glow animation will highlight the cast bar.
+*   **Movable Frame**:
+    *   The cast bar can be repositioned on the screen.
+    *   If the `asMOD` addon is installed, its position can be managed and saved via `asMOD`'s configuration system.
+*   **Tooltip on Hover**: Shows the game's spell tooltip when you mouse over the cast bar.
+
+## How it Works
+
+1.  The addon creates a status bar for the cast progress and a button frame for the spell icon.
+2.  It listens to `UNIT_SPELLCAST_*` events for your current target.
+3.  When the target begins casting:
+    *   It populates the bar with the spell's icon, name, and time.
+    *   It determines the appropriate color for the bar based on interruptibility and if the player is the target of the spell.
+    *   It checks against DBM's dangerous spell list and applies a glow if necessary.
+    *   It shows the target's target if it's a player.
+4.  The bar updates its progress via a periodic timer and event updates.
+5.  When the cast ends or is interrupted, the bar is hidden.
+
+## Configuration
+
+Basic configuration is done by editing Lua variables at the top of `asTargetCastBar/asTargetCastBar.lua`:
+
+*   `ATCB_WIDTH`: Width of the cast bar (excluding the icon width). (Default: 180)
+*   `ATCB_HEIGHT`: Height of the cast bar. (Default: 17)
+*   `ATCB_X`, `ATCB_Y`: Default X and Y offsets from the screen center for the cast bar's anchor. (Defaults: 0, -100)
+*   `ATCB_ALPHA`: Transparency of the cast bar. (Default: 0.8)
+*   `ATCB_NAME_SIZE`, `ATCB_TIME_SIZE`: Font sizes for spell name and time text, relative to bar height.
+*   `CONFIG_*_COLOR` variables: Define the RGB colors for the different interrupt/target states.
+
+If `asMOD` is installed, the position of the bar ("asTargetCastBar") can be more easily adjusted and saved using `asMOD`'s interface. The glow effects are provided by `asTargetCastBarLib.lua`.
+
+**Note**: This addon does not provide an in-game configuration panel for these settings without `asMOD`.
+
+---
+
+# asTargetCastBar
+
+asTargetCastBar는 현재 대상의 시전 바를 전용으로 표시하며 이동 가능한 월드 오브 워크래프트 애드온입니다. 주문 차단 가능성, 주문이 자신을 대상으로 하는지 여부에 대한 시각적 신호를 제공하며, DBM과 연동하여 위험한 주문을 강조 표시합니다.
+
+## 주요 기능
+
+*   **전용 대상 시전 바**: 현재 대상이 시전하는 모든 주문 또는 채널링 주문에 대한 명확한 시전 바를 표시합니다.
+*   **시각 정보**:
+    *   **주문 아이콘**: 시전 중인 주문의 아이콘을 표시합니다.
+    *   **주문 이름**: 주문의 이름을 표시합니다.
+    *   **시전 시간**: 숫자 형식의 `현재 / 전체` 시전 시간을 표시합니다.
+    *   **대상의 대상**: 대상이 다른 플레이어에게 주문을 시전하는 경우, 해당 플레이어의 이름이 시전 바 아래에 직업 색상으로 표시됩니다.
+*   **색상으로 구분된 차단 상태**:
+    *   시전 바는 다음 기준에 따라 색상이 변경됩니다:
+        *   주문 차단 가능 여부.
+        *   주문이 자신(플레이어)을 대상으로 하는지 여부.
+    *   기본 색상은 위협 및 차단 기회를 빠르게 식별하는 데 도움이 됩니다:
+        *   어두운 분홍색/보라색: 차단 불가능, 자신 대상.
+        *   회색: 차단 불가능, 자신이 대상 아님.
+        *   녹색: 차단 가능, 자신 대상.
+        *   밝은 녹색/노란색: 차단 가능, 자신이 대상 아님.
+*   **DBM 연동 (위험 주문)**:
+    *   DBM (Deadly Boss Mods)이 설치된 경우, 애드온은 DBM 데이터를 스캔합니다.
+    *   대상이 DBM이 위험한 "차단" 유형으로 지정한 주문을 시전하는 경우, 픽셀 강조 애니메이션이 시전 바를 강조 표시합니다.
+*   **이동 가능한 프레임**:
+    *   시전 바는 화면에서 위치를 변경할 수 있습니다.
+    *   `asMOD` 애드온이 설치된 경우, 해당 위치는 `asMOD`의 설정 시스템을 통해 관리하고 저장할 수 있습니다.
+*   **마우스오버 시 툴팁**: 시전 바에 마우스를 올리면 게임의 주문 툴팁을 표시합니다.
+
+## 작동 방식
+
+1.  애드온은 시전 진행을 위한 상태 바와 주문 아이콘을 위한 버튼 프레임을 생성합니다.
+2.  현재 대상에 대한 `UNIT_SPELLCAST_*` 이벤트를 수신합니다.
+3.  대상이 시전을 시작하면:
+    *   주문의 아이콘, 이름 및 시간으로 바를 채웁니다.
+    *   차단 가능성 및 플레이어가 주문의 대상인지 여부에 따라 바의 적절한 색상을 결정합니다.
+    *   DBM의 위험 주문 목록과 대조하여 필요한 경우 강조 효과를 적용합니다.
+    *   대상의 대상이 플레이어인 경우 이를 표시합니다.
+4.  바는 주기적인 타이머 및 이벤트 업데이트를 통해 진행 상황을 업데이트합니다.
+5.  시전이 종료되거나 중단되면 바가 숨겨집니다.
+
+## 설정
+
+기본 설정은 `asTargetCastBar/asTargetCastBar.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `ATCB_WIDTH`: 시전 바의 너비 (아이콘 너비 제외). (기본값: 180)
+*   `ATCB_HEIGHT`: 시전 바의 높이. (기본값: 17)
+*   `ATCB_X`, `ATCB_Y`: 시전 바 앵커의 화면 중앙으로부터의 기본 X 및 Y 오프셋. (기본값: 0, -100)
+*   `ATCB_ALPHA`: 시전 바의 투명도. (기본값: 0.8)
+*   `ATCB_NAME_SIZE`, `ATCB_TIME_SIZE`: 주문 이름 및 시간 텍스트의 글꼴 크기 (바 높이 기준).
+*   `CONFIG_*_COLOR` 변수: 다양한 차단/대상 상태에 대한 RGB 색상을 정의합니다.
+
+`asMOD`가 설치된 경우, "asTargetCastBar" 바의 위치는 `asMOD`의 인터페이스를 사용하여 더 쉽게 조정하고 저장할 수 있습니다. 강조 효과는 `asTargetCastBarLib.lua`에서 제공됩니다.
+
+**참고**: 이 애드온은 `asMOD` 없이는 이러한 설정을 위한 게임 내 설정 패널을 제공하지 않습니다.

--- a/asTrueGCD/README.md
+++ b/asTrueGCD/README.md
@@ -1,0 +1,97 @@
+# asTrueGCD
+
+asTrueGCD is a World of Warcraft addon that provides a visual display of your character's current spell cast and a short history of recently used spells and items. It aims to offer a clearer representation of actions, especially concerning the Global Cooldown (GCD).
+
+## Main Features
+
+*   **Current Cast Display**:
+    *   Shows a prominent icon of the spell or item currently being cast or channeled by your character.
+    *   A cooldown-style spiral overlay indicates the progress of the current cast.
+    *   If the same spell is cast multiple times consecutively, a counter appears on this main icon.
+
+*   **Spell/Item History**:
+    *   Displays icons for the last three successfully cast spells or used items in a row to the left of the current cast icon.
+    *   **Interruption Indicator**: If a spell cast is interrupted, its icon in the history will be marked with an "X".
+    *   **Sequential Cast Counter**: If the same spell/item is used multiple times in a row (and registered as distinct GCD actions), a counter will appear on its history icon.
+    *   History icons fade out after approximately 5 seconds.
+
+*   **"TrueGCD" Logic (Attempted)**:
+    *   The addon includes logic that tries to prevent logging the same spell multiple times in the history if those casts occur very rapidly within a single Global Cooldown window. This helps to show distinct actions rather than every single `UNIT_SPELLCAST_SUCCEEDED` event if they are part of one GCD.
+
+*   **Item Spell Tracking**: Scans equipped items (like trinkets) to correctly display icons for spells cast from items.
+*   **Blacklist**: Ignores certain common, low-impact spells (e.g., Auto Attack) to keep the display relevant.
+*   **Movable Frame**: The entire group of icons (current cast + history) can be repositioned. If `asMOD` is installed, its position can be managed via `asMOD`'s configuration.
+
+## How it Works
+
+1.  **Frame Setup**: The addon creates a main icon frame for the current cast and three smaller icon frames for the spell history.
+2.  **Event Monitoring**: It listens to various `UNIT_SPELLCAST_*` events for the player.
+    *   `_START` / `_CHANNEL_START`: Updates the main icon with the current spell and initiates a cast progress animation.
+    *   `_STOP` / `_CHANNEL_STOP`: Clears the main icon if the cast finishes or is stopped.
+    *   `_SUCCEEDED`: This is the primary trigger for the history. It records the spell/item, unless it's a blacklisted spell or an immediate re-cast of the exact same spell within the GCD duration.
+    *   `_INTERRUPTED`: Records the spell in history but marks it as canceled.
+3.  **History Management**: Successfully cast or canceled spells are added to a list. A periodic timer updates the three history icons based on this list.
+4.  **Positioning**: The main icon's position is configurable, and history icons are anchored relative to it.
+
+## Configuration
+
+Basic configuration is done by editing Lua variables at the top of `asTrueGCD/asTrueGCD.lua`:
+
+*   `ATGCD_X`, `ATGCD_Y`: Default X and Y offsets from the screen center for the main (current cast) icon. The history icons are positioned to its left. (Defaults: 56, -360)
+*   `AGCICON`: Base size in pixels for the icons. The main current cast icon is slightly larger (1.3x). (Default: 25)
+
+If `asMOD` is installed, the position of the main icon group ("asTrueGCD") can be more easily adjusted and saved using `asMOD`'s interface.
+
+The `AGCD_BlackList` table in the Lua file can be modified by advanced users to add or remove spell IDs that should be ignored by the history display.
+
+**Note**: This addon does not provide an in-game configuration panel for its settings without `asMOD`.
+
+---
+
+# asTrueGCD
+
+asTrueGCD는 현재 시전 중인 주문과 최근 사용한 주문 및 아이템의 짧은 기록을 시각적으로 표시하는 월드 오브 워크래프트 애드온입니다. 특히 전역 재사용 대기시간(GCD)과 관련하여 행동을 더 명확하게 표현하는 것을 목표로 합니다.
+
+## 주요 기능
+
+*   **현재 시전 표시**:
+    *   캐릭터가 현재 시전 또는 채널링 중인 주문이나 아이템의 아이콘을 눈에 띄게 표시합니다.
+    *   재사용 대기시간 스타일의 효과가 현재 시전 진행 상황을 나타냅니다.
+    *   동일한 주문을 연속으로 여러 번 시전하면 이 주 아이콘에 카운터가 나타납니다.
+
+*   **주문/아이템 기록**:
+    *   현재 시전 아이콘의 왼쪽에 성공적으로 시전했거나 사용한 마지막 세 개의 주문 또는 아이템 아이콘을 순서대로 표시합니다.
+    *   **차단 표시**: 주문 시전이 차단되면 기록의 해당 아이콘에 "X"가 표시됩니다.
+    *   **연속 시전 카운터**: 동일한 주문/아이템을 연속으로 여러 번 사용한 경우(그리고 별개의 GCD 행동으로 등록된 경우), 해당 기록 아이콘에 카운터가 표시됩니다.
+    *   기록 아이콘은 약 5초 후에 사라집니다.
+
+*   **"TrueGCD" 로직 (시도)**:
+    *   애드온은 단일 전역 재사용 대기시간 창 내에서 매우 빠르게 발생한 경우 동일한 주문을 기록에 여러 번 기록하는 것을 방지하려는 로직을 포함합니다. 이는 하나의 GCD에 속하는 모든 `UNIT_SPELLCAST_SUCCEEDED` 이벤트 대신 별개의 행동을 보여주는 데 도움이 됩니다.
+
+*   **아이템 주문 추적**: 장착한 아이템(예: 장신구)을 스캔하여 아이템에서 시전된 주문의 아이콘을 올바르게 표시합니다.
+*   **블랙리스트**: 관련성 있는 표시를 유지하기 위해 특정 일반적이고 영향이 적은 주문(예: 자동 공격)을 무시합니다.
+*   **이동 가능한 프레임**: 전체 아이콘 그룹(현재 시전 + 기록)의 위치를 변경할 수 있습니다. `asMOD`가 설치된 경우 해당 위치는 `asMOD`의 설정을 통해 관리할 수 있습니다.
+
+## 작동 방식
+
+1.  **프레임 설정**: 애드온은 현재 시전을 위한 주 아이콘 프레임과 주문 기록을 위한 세 개의 작은 아이콘 프레임을 생성합니다.
+2.  **이벤트 감시**: 플레이어에 대한 다양한 `UNIT_SPELLCAST_*` 이벤트를 수신합니다.
+    *   `_START` / `_CHANNEL_START`: 현재 주문으로 주 아이콘을 업데이트하고 시전 진행 애니메이션을 시작합니다.
+    *   `_STOP` / `_CHANNEL_STOP`: 시전이 완료되거나 중지되면 주 아이콘을 지웁니다.
+    *   `_SUCCEEDED`: 이것이 기록의 주된 트리거입니다. 블랙리스트에 있는 주문이거나 GCD 지속 시간 내에 정확히 동일한 주문을 즉시 다시 시전한 경우가 아니면 주문/아이템을 기록합니다.
+    *   `_INTERRUPTED`: 주문을 기록에 남기지만 취소된 것으로 표시합니다.
+3.  **기록 관리**: 성공적으로 시전했거나 취소된 주문이 목록에 추가됩니다. 주기적인 타이머가 이 목록을 기반으로 세 개의 기록 아이콘을 업데이트합니다.
+4.  **위치 지정**: 주 아이콘의 위치는 설정 가능하며, 기록 아이콘은 이를 기준으로 고정됩니다.
+
+## 설정
+
+기본 설정은 `asTrueGCD/asTrueGCD.lua` 파일 상단의 Lua 변수를 편집하여 수행합니다:
+
+*   `ATGCD_X`, `ATGCD_Y`: 주 (현재 시전) 아이콘의 화면 중앙으로부터의 기본 X 및 Y 오프셋입니다. 기록 아이콘은 그 왼쪽에 위치합니다. (기본값: 56, -360)
+*   `AGCICON`: 아이콘의 기본 크기(픽셀 단위)입니다. 주 현재 시전 아이콘은 약간 더 큽니다(1.3배). (기본값: 25)
+
+`asMOD`가 설치된 경우, 주 아이콘 그룹("asTrueGCD")의 위치는 `asMOD`의 인터페이스를 사용하여 더 쉽게 조정하고 저장할 수 있습니다.
+
+Lua 파일의 `AGCD_BlackList` 테이블은 고급 사용자가 수정하여 기록 표시에 의해 무시되어야 하는 주문 ID를 추가하거나 제거할 수 있습니다.
+
+**참고**: 이 애드온은 `asMOD` 없이는 해당 설정을 위한 게임 내 설정 패널을 제공하지 않습니다.


### PR DESCRIPTION
This commit adds README.md files with bilingual (English and Korean) descriptions to all remaining addons that I identified as missing them after a re-evaluation of the main branch.

The following addons now have README.md files:
- asInformation
- asInterruptHelper
- asMisdirection
- asPremadeGroupsFilter
- asRangeDisplay
- asReady
- asScavenger
- asSpamFilter
- asTargetCastBar
- asTrueGCD

For each addon, I:
1. Examined the addon's Lua file(s) to understand its functionality, features, and configuration options.
2. Drafted a comprehensive description in English.
3. Translated the English content to Korean.
4. Structured both descriptions into a new README.md file, following the established bilingual format.

This completes the task of ensuring all addons have a descriptive README file.