### PR TITLE
Feat: asDBMTimer 위치 이동 기능 추가

### DIFF
--- a/asDBMTimer/asDBMTimer.lua
+++ b/asDBMTimer/asDBMTimer.lua
@@ -355,15 +355,35 @@ local function setupUI()
 	asDBMTimer:SetPoint("CENTER", UIParent, "CENTER", ADBMT_X, ADBMT_Y)
 	asDBMTimer:SetWidth(100)
 	asDBMTimer:SetHeight(100)
+	asDBMTimer:SetMovable(true);
+	asDBMTimer:EnableMouse(true);
+	asDBMTimer:RegisterForDrag("LeftButton");
+	asDBMTimer.text = asDBMTimer:CreateFontString(nil, "OVERLAY")
+	asDBMTimer.text:SetFont(STANDARD_TEXT_FONT, 10, "OUTLINE")
+	asDBMTimer.text:SetPoint("CENTER", asDBMTimer, "CENTER", 0, 0)
+	asDBMTimer.text:SetText("asDBMTimer(Position)");
+	local tex = asDBMTimer:CreateTexture(nil, "ARTWORK");
+	tex:SetAllPoints();
+	tex:SetColorTexture(0.0, 0.5, 1.0); -- Blue color for visibility
+	tex:SetAlpha(0.5);
 	asDBMTimer:Show();
 	asDBMTimer:SetScript("OnEvent", asDBMTimer_OnEvent);
 	asDBMTimer:RegisterEvent("COMBAT_LOG_EVENT_UNFILTERED");
+
+	asDBMTimer:SetScript("OnDragStart", function(self)
+		self:StartMoving();
+	end)
+	asDBMTimer:SetScript("OnDragStop", function(self)
+		self:StopMovingOrSizing();
+		ns.SavePosition(self);
+	end);
 
 
 	local bloaded = C_AddOns.LoadAddOn("asMOD")
 
 	if bloaded and asMOD_setupFrame then
 		asMOD_setupFrame(asDBMTimer, "asDBMTimer");
+		ns.SavePosition(asDBMTimer); -- Save position after asMOD_setupFrame
 	end
 
 	asDBMTimer.buttons = {};
@@ -433,6 +453,14 @@ local function initAddon()
 
 	C_Timer.NewTicker(0.2, checkList);
 	C_Timer.NewTicker(0.05, checkButtons);
+end
+
+function ns.GetPosition()
+    local left = asDBMTimer:GetLeft();
+    local bottom = asDBMTimer:GetBottom();
+    local height = asDBMTimer:GetHeight();
+
+    return left, bottom, height;
 end
 
 local bloaded = C_AddOns.LoadAddOn("DBM-Core");

--- a/asDBMTimer/asDBMTimerOption.lua
+++ b/asDBMTimer/asDBMTimerOption.lua
@@ -5,7 +5,16 @@ local Options_Default = {
     HideNamePlatesCooldown = false,
     ShowInterruptOnlyforNormal = true,
     AOESound = 2.5,
+    LockPosition = true, -- 위치 잠금 옵션 추가
 };
+
+local OtherOptions_Default = {
+    point = "CENTER",
+    point2 = "CENTER",
+    x = 200, -- 기본 X 위치 (asDBMTimer.lua의 ADBMT_X와 동일하게 설정)
+    y = 50,  -- 기본 Y 위치 (asDBMTimer.lua의 ADBMT_Y와 동일하게 설정)
+    version = 240808, -- 버전 업데이트
+}
 
 ns.options = CopyTable(Options_Default);
 local tempoption = {};
@@ -29,10 +38,15 @@ function ns.SetupOptionPanels()
 
     if ADTI_Options == nil or Options_Default.Version ~= ADTI_Options.Version then
         ADTI_Options = {};
-        ADTI_Options = CopyTable(Options_Default);        
+        ADTI_Options = CopyTable(Options_Default);
     end
 
-    ns.options = CopyTable(ADTI_Options);    
+    if ADTI_OtherOptions == nil or OtherOptions_Default.version ~= ADTI_OtherOptions.version then
+        ADTI_OtherOptions = {};
+        ADTI_OtherOptions = CopyTable(OtherOptions_Default);
+    end
+
+    ns.options = CopyTable(ADTI_Options);
 
     for variable, _ in pairs(Options_Default) do
         local name = variable;
@@ -42,12 +56,30 @@ function ns.SetupOptionPanels()
             local tooltip = ""
             if ADTI_Options[variable] == nil  then
                 ADTI_Options[variable] = Options_Default[variable];
-                ns.options[variable] = Options_Default[variable];                
+                ns.options[variable] = Options_Default[variable];
             end
             local defaultValue = Options_Default[variable]
             local currentValue = ADTI_Options[variable];
 
-            if tonumber(defaultValue) ~= nil then
+            if variable == "LockPosition" then -- LockPosition 옵션 처리
+                local setting = Settings.RegisterAddOnSetting(category, cvar_name,  variable, tempoption, type(defaultValue), name, defaultValue);
+                Settings.CreateCheckboxWithOptions(category, setting, nil, tooltip);
+                Settings.SetValue(cvar_name, currentValue);
+                Settings.SetOnValueChangedCallback(cvar_name, function(_, setting, value)
+                    OnSettingChanged(_, setting, value)
+                    if _G["asDBMTimer"] then
+                        if value == true then
+                            _G["asDBMTimer"]:EnableMouse(false);
+                            _G["asDBMTimer"].text:Hide();
+                            _G["asDBMTimer"]:GetChildren():SetAlpha(0); -- Hide texture
+                        else
+                            _G["asDBMTimer"]:EnableMouse(true);
+                            _G["asDBMTimer"].text:Show();
+                            _G["asDBMTimer"]:GetChildren():SetAlpha(0.5); -- Show texture
+                        end
+                    end
+                end);
+            elseif tonumber(defaultValue) ~= nil then
                 local setting = Settings.RegisterAddOnSetting(category, cvar_name,  variable, tempoption, type(defaultValue), name, defaultValue);
                 local options = Settings.CreateSliderOptions(0, 100, 1);
                 options:SetLabelFormatter(MinimalSliderWithSteppersMixin.Label.Right);
@@ -56,7 +88,6 @@ function ns.SetupOptionPanels()
                 Settings.SetOnValueChangedCallback(cvar_name, OnSettingChanged);
             else
                 local setting = Settings.RegisterAddOnSetting(category, cvar_name,  variable, tempoption, type(defaultValue), name, defaultValue);
-                
                 Settings.CreateCheckboxWithOptions(category, setting, nil, tooltip);
                 Settings.SetValue(cvar_name, currentValue);
                 Settings.SetOnValueChangedCallback(cvar_name, OnSettingChanged);
@@ -65,4 +96,37 @@ function ns.SetupOptionPanels()
     end
 
     Settings.RegisterAddOnCategory(category)
+    ns.LoadPosition();
+
+    C_AddOns.LoadAddOn("asMOD");
+    if _G["asMOD_setupFrame"] and _G["asDBMTimer"] then
+        _G["asMOD_setupFrame"](_G["asDBMTimer"], "asDBMTimer");
+        ns.SavePosition(_G["asDBMTimer"]); -- Save position after asMOD_setupFrame
+    end
+
+    if ns.options.LockPosition and _G["asDBMTimer"] then
+        _G["asDBMTimer"]:EnableMouse(false);
+        _G["asDBMTimer"].text:Hide();
+        _G["asDBMTimer"]:GetChildren():SetAlpha(0); -- Hide texture
+    elseif _G["asDBMTimer"] then
+        _G["asDBMTimer"]:EnableMouse(true);
+        _G["asDBMTimer"].text:Show();
+        _G["asDBMTimer"]:GetChildren():SetAlpha(0.5); -- Show texture
+    end
+end
+
+function ns.LoadPosition()
+    if _G["asDBMTimer"] then
+        _G["asDBMTimer"]:ClearAllPoints()
+        _G["asDBMTimer"]:SetPoint(ADTI_OtherOptions.point, UIParent, ADTI_OtherOptions.point2, ADTI_OtherOptions.x, ADTI_OtherOptions.y);
+    end
+end
+
+function ns.SavePosition(frame)
+    if frame then
+        ADTI_OtherOptions.point, _, ADTI_OtherOptions.point2, ADTI_OtherOptions.x, ADTI_OtherOptions.y = frame:GetPoint();
+        if frame.StopMovingOrSizing then
+            frame:StopMovingOrSizing();
+        end
+    end
 end


### PR DESCRIPTION
asFixCombatText를 참고하여 asDBMTimer에도 위치 이동 및 잠금 기능을 추가했습니다.

- 마우스 드래그로 DBM 타이머 창의 위치를 조절할 수 있습니다.
- 애드온 설정에서 'LockPosition' 옵션을 통해 위치를 고정하거나 해제할 수 있습니다.
- 변경된 위치와 잠금 설정은 저장되어 게임 재시작 시에도 유지됩니다.